### PR TITLE
goal-driven: rename journal → record

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of [agent skills](https://agentskills.io) — reusable methodology 
 | Skill | Command | Description |
 |-------|---------|-------------|
 | [design-driven](skills/design-driven/SKILL.md) | `/design-driven` | Design-driven development methodology. The `design/` directory is the single source of architectural truth — read it before coding, update the design before changing the system's shape. |
+| [goal-driven](skills/goal-driven/SKILL.md) | `/goal-driven` | Goal-driven methodology for strategy-layer initiatives where the destination is clearer than the path. `GOAL.md` is the stable compass (north star + falsifiable criteria); the record captures what was tried and whether each criterion is still served. Pairs with design-driven. |
 | [harness](skills/harness/SKILL.md) | `/harness` | Agent harness architecture — structure a project's agent context across layers (L1 architecture → L2 design → L3 implementation) for effective AI-assisted development. |
 
 ## Installation
@@ -19,6 +20,7 @@ This installs all skills from the repository. To install a specific skill:
 
 ```bash
 npx skills install lidessen/skills/design-driven
+npx skills install lidessen/skills/goal-driven
 npx skills install lidessen/skills/harness
 ```
 
@@ -28,6 +30,11 @@ Then invoke a skill in any conversation:
 /design-driven              # Run the main loop
 /design-driven init         # First-time project configuration
 /design-driven bootstrap    # Generate design from existing codebase
+
+/goal-driven                # Continue the running protocol
+/goal-driven set            # Interview-driven GOAL.md + scaffolding
+/goal-driven review         # Strategic checkpoint + maintenance
+/goal-driven close          # Project closure + retrospective
 
 /harness                    # Context layer methodology
 /harness audit              # Evaluate existing project's context architecture

--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -3,9 +3,9 @@ name: goal-driven
 description: |
   Goal-driven methodology for initiatives where the destination is clearer
   than the path. GOAL.md is the stable compass — north star plus falsifiable
-  success criteria. The journal is the living record of what was tried, what
-  was observed, and whether each criterion is still served. The agent writes
-  both files; the human approves edits via chat.
+  success criteria. The record captures what was tried, what was observed,
+  and whether each criterion is still served. The agent writes both files;
+  the human approves edits via chat.
 
   Use this skill for multi-week initiatives where upfront design is the
   wrong tool: research, exploratory features, learning projects with a
@@ -37,7 +37,7 @@ argument-hint: "[set | review | close]"
 A mini methodology for initiatives where the destination is fixed but the
 path isn't. Human owns the compass; agent walks the path and keeps the log.
 
-GOAL.md is the institutional memory of *why*. The journal is the
+GOAL.md is the institutional memory of *why*. The record is the
 institutional memory of *what was tried*. Together they let a fresh agent —
 or future-you — pick up a months-long initiative without losing direction.
 
@@ -59,7 +59,7 @@ When invoked with an argument, dispatch to the corresponding file:
 **Which command when:**
 
 - New initiative → `set`
-- ≥ 2 weeks since last review, journal feels overgrown, midpoint of an
+- ≥ 2 weeks since last review, record feels overgrown, midpoint of an
   explicit timeline, or you sense you've drifted → `review`
 - Initiative is done, abandoned, or superseded → `close`
 - Mid-work, just logging progress → no argument (normal loop)
@@ -98,13 +98,13 @@ project/
 └── goals/
     ├── GOAL.md                  ← Stable compass (north star, criteria, invariants)
     ├── OPEN-STOPS.md            ← Index of unresolved STOP signals
-    ├── journal-2026-04.md       ← Past month
-    └── journal-2026-05.md       ← Current month (auto-rotates monthly)
+    ├── record-2026-04.md       ← Past month
+    └── record-2026-05.md       ← Current month (auto-rotates monthly)
 ```
 
-Two stable files (GOAL.md, OPEN-STOPS.md) plus monthly journals. No
+Two stable files (GOAL.md, OPEN-STOPS.md) plus monthly records. No
 `archive/` directory by default — old months stay in place. If `goals/`
-becomes crowded after a year, move them under `goals/journal-archive/`
+becomes crowded after a year, move them under `goals/record-archive/`
 manually; the convention is informal.
 
 ## The compass / path asymmetry
@@ -121,7 +121,7 @@ The path mutates constantly. The compass mutates only when:
 Both are deliberate, human-approved events. They are NOT what happens when
 "I tried X and it didn't work, let me try Y" — that's just walking.
 
-This asymmetry is the whole point. If GOAL.md and the journal change at the
+This asymmetry is the whole point. If GOAL.md and the record change at the
 same rate, you don't have a compass; you have a notebook.
 
 ## Permission gradient
@@ -129,7 +129,7 @@ same rate, you don't have a compass; you have a notebook.
 | File | Who writes | When | Human's role |
 |---|---|---|---|
 | `GOAL.md` | agent | Only at initial set or explicit GOAL change | Approves each section, line by line |
-| `journal-YYYY-MM.md` | agent | End of session, or on STOP / rotation | Reviews entry draft in chat before write |
+| `record-YYYY-MM.md` | agent | End of session, or on STOP / rotation | Reviews entry draft in chat before write |
 | `OPEN-STOPS.md` | agent | When a STOP is created or resolved | Confirms the line in chat |
 | STOP signals | agent surfaces | When trigger condition hit | Decides: change path / change goal / agent misjudged |
 
@@ -170,7 +170,7 @@ moves on. GOAL.md is written only after all sections are confirmed. See
 
 ### Moment 2 — End of every work session
 
-Before the session ends, the agent drafts a journal entry **in the chat**:
+Before the session ends, the agent drafts a record entry **in the chat**:
 
 ```
 Entry draft:
@@ -185,7 +185,7 @@ Confirm and append?
 ```
 
 The human confirms or edits in chat. Only then does the agent append to
-the current month's journal.
+the current month's record.
 
 **The criteria check is the heart of the discipline.** Each ✓/✗ must cite
 a concrete observation from the session. `C1 ✓` without evidence is
@@ -249,7 +249,7 @@ solves the wrong problem.
 
 **Critical:** STOPs are never silently logged and walked past. The agent
 must surface them in chat AND wait for the human's choice before continuing
-work. A STOP entry in the journal without a chat exchange is a protocol
+work. A STOP entry in the record without a chat exchange is a protocol
 violation.
 
 ## Anti-flattery: the evidence rule
@@ -274,14 +274,14 @@ within weeks.
 
 ## Maintenance
 
-Three things rot if untended: journal volume grows unboundedly, open
+Three things rot if untended: record volume grows unboundedly, open
 STOPs across files get forgotten, GOAL.md drifts inconsistent after
-edits. The protocol handles each — month-bounded journal files cap
+edits. The protocol handles each — month-bounded record files cap
 volume once the project is long enough to warrant them, OPEN-STOPS.md
 indexes unresolved STOPs across files when more than one is in flight,
 and `/goal-driven review` periodically reconciles all three plus
 re-assesses strategy. See `commands/review.md` for what review covers;
-`references/templates.md` for journal, STOP, OPEN-STOPS, and carry-over
+`references/templates.md` for record, STOP, OPEN-STOPS, and carry-over
 formats.
 
 Review when ≥ 2 weeks pass since the last one, ≥ 30 new entries
@@ -292,19 +292,19 @@ fresh agent picks up the project, or things just feel off.
 
 Goal-driven works alone. Shape decisions, when they come up in an
 exploratory project, live as observations or named alternatives in the
-journal — no separate proposal flow needed. This is the default mode and
+record — no separate proposal flow needed. This is the default mode and
 what the rest of this document assumes.
 
 If design-driven is also installed in the project, the two divide labor:
 goal-driven owns *why* and *how-far*; design-driven owns *what-shape*.
 Each manages its own files; cross-references go by ID, not content (a
-journal entry says "adopted decision 003"; a decision says "blocks goal
+record entry says "adopted decision 003"; a decision says "blocks goal
 STOP 2026-05-02 if rejected").
 
 Four interaction points to watch when both are present:
 
 1. **Goal pivot crosses design boundaries** → also open a
-   `design/decisions/NNN-*.md` proposal. The journal entry doesn't
+   `design/decisions/NNN-*.md` proposal. The record entry doesn't
    replace the design proposal flow.
 2. **Design proposal would violate GOAL invariants** → trigger a goal
    Type A STOP first; don't let design adopt and then quietly fail
@@ -312,23 +312,23 @@ Four interaction points to watch when both are present:
 3. **STOP resolution requires shape change** → resolve the goal STOP
    first, then open a design decision.
 4. **Cross-checks during periodic inspection** — goal-driven's review
-   surfaces design decisions not reflected in the journal; design-driven's
+   surfaces design decisions not reflected in the record; design-driven's
    audit surfaces GOAL invariants potentially at risk. (The two skills
    use different command names — `review` vs `audit` — for the same
    periodic-inspection role.)
 
 ## Structure follows need
 
-The scaffolding around GOAL.md — OPEN-STOPS.md, monthly journal rotation,
+The scaffolding around GOAL.md — OPEN-STOPS.md, monthly record rotation,
 periodic reviews — earns its cost when it's load-bearing. A short, single-stream
 initiative with no STOPs in sight doesn't need an OPEN-STOPS index; the
-one STOP, if it ever appears, lives visibly in the journal. A six-week
-project doesn't need monthly rotation; a single `journal.md` carries it
+one STOP, if it ever appears, lives visibly in the record. A six-week
+project doesn't need monthly rotation; a single `record.md` carries it
 until it doesn't.
 
 Add structure when the absence starts to hurt: create OPEN-STOPS.md when
 a second open STOP exists and you can no longer hold both in mind; rotate
-to monthly files when one journal becomes too long to scan. The directory
+to monthly files when one record becomes too long to scan. The directory
 layout shown above is the mature shape, not the starting shape — start
 small and grow into it.
 
@@ -339,5 +339,5 @@ notebook.
 
 ## Example walkthrough
 
-For a concrete end-to-end example — set, several journal entries,
+For a concrete end-to-end example — set, several record entries,
 two STOP scenarios, resolution — see `references/example.md`.

--- a/skills/goal-driven/commands/close.md
+++ b/skills/goal-driven/commands/close.md
@@ -27,17 +27,17 @@ before doing anything else.
 
 Load:
 - `goals/GOAL.md` (compass + Revisions history)
-- The full journal (or all monthly journals if rotated)
+- The full record (or all monthly records if rotated)
 - `goals/OPEN-STOPS.md` if present
 
-For long-running projects, the full journal can be substantial. Skim
+For long-running projects, the full record can be substantial. Skim
 for the major beats: kickoff, pivots, resolved STOPs, biggest entries.
 The retrospective is a synthesis, not a transcript.
 
 ### 2. Draft the retrospective
 
 Compose a retrospective entry **in chat** — same protocol as any
-journal entry, evidence-based, no naked claims. Suggested structure:
+record entry, evidence-based, no naked claims. Suggested structure:
 
 ```markdown
 ## YYYY-MM-DD — Retrospective (close: <achieved | abandoned | superseded>)
@@ -79,7 +79,7 @@ Get human confirmation before writing. Edit until they say yes.
 Append to the Revisions section:
 
 ```
-- YYYY-MM-DD: project closed (<state>). See retrospective in journal.
+- YYYY-MM-DD: project closed (<state>). See retrospective in record.
 ```
 
 Add a status line at the top, near the north-star paragraph:
@@ -92,7 +92,7 @@ Don't delete content. The closed GOAL.md is a historical record.
 
 ### 4. Append the retrospective entry
 
-Write the retrospective entry as the final entry in the current journal
+Write the retrospective entry as the final entry in the current record
 file (or in a new month's file if the close happens at month boundary).
 
 If `OPEN-STOPS.md` exists with unresolved entries: leave it. The
@@ -126,7 +126,7 @@ One commit, clear message: `goal-driven: close <project-name> (<state>)`.
 ## When close is wrong
 
 Don't close just because the project paused. Close is for terminal
-states; pauses go into the journal as ordinary entries (e.g.,
+states; pauses go into the record as ordinary entries (e.g.,
 `## YYYY-MM-DD — Pausing for ~6 weeks`). Closing and re-running `set`
 on resumption loses the audit trail.
 

--- a/skills/goal-driven/commands/review.md
+++ b/skills/goal-driven/commands/review.md
@@ -11,7 +11,7 @@ whether the human meant `/goal-driven set` instead.
 ## When to run
 
 - ≥ 2 weeks since the last review
-- ≥ 30 new journal entries since the last review
+- ≥ 30 new record entries since the last review
 - The midpoint of an explicit project timeline (e.g., month 3 of a
   6-month initiative — don't wait for the end to find out you're off)
 - A new agent picks up the project (sanity-check inherited state)
@@ -20,7 +20,7 @@ whether the human meant `/goal-driven set` instead.
 
 ## Phase 1 — Strategic checkpoint
 
-Read GOAL.md and the journal in order. The point is to re-establish
+Read GOAL.md and the record in order. The point is to re-establish
 situational awareness, not to find drift (that's Phase 2). Ask:
 
 **Trajectory of each criterion.** For criteria with deadlines or pace
@@ -38,7 +38,7 @@ through phases — re-identify from current evidence.
 **The implicit theory of getting there.** Most projects start with an
 unstated theory ("if we ship 4 articles per week, organic growth
 follows"; "if we get pgvector under 500ms, the feature is viable"). Has
-the theory survived contact with reality? If not, the journal-level
+the theory survived contact with reality? If not, the record-level
 path adjustments may be patching a flawed premise — surface this even
 if no single entry shows it.
 
@@ -59,7 +59,7 @@ don't write to files yet.
 
 **Index sync (only if `OPEN-STOPS.md` exists).** Every line in
 OPEN-STOPS should resolve to a real STOP entry that's still open;
-every unresolved STOP entry in the journals should appear as a line in
+every unresolved STOP entry in the records should appear as a line in
 OPEN-STOPS. Mismatches mean the protocol was violated somewhere — the
 review fixes the index, but also note when the violation happened so the
 underlying habit can be addressed.
@@ -80,8 +80,8 @@ without a parenthetical citing observation from that session. Many
 naked verdicts in a row mean the discipline is decaying — surface this
 prominently, since it's the leading indicator of the whole skill failing.
 
-**Rotation skipped or misfiled (only if using monthly journals).** The
-most recent journal file should match the current month, and the
+**Rotation skipped or misfiled (only if using monthly records).** The
+most recent record file should match the current month, and the
 month's first entry should be a carry-over summary. If neither, rotation
 happened wrong or not at all.
 
@@ -93,9 +93,9 @@ internally consistent because it changes rarely; once that assumption
 breaks, every later criteria check is judging against confused targets.
 
 **Cross-skill drift (only if design-driven is installed).** Recent
-`design/decisions/` adopted but not mentioned in the journal — a shape
+`design/decisions/` adopted but not mentioned in the record — a shape
 change the goal layer missed. Design decisions that would violate GOAL
-invariants. Goal pivots logged in journal that crossed module boundaries
+invariants. Goal pivots logged in record that crossed module boundaries
 without opening a design proposal. None are errors per se; they're worth
 the human's attention.
 
@@ -149,7 +149,7 @@ approval in chat.
 For OPEN-STOPS sync issues:
 - If a STOP exists but isn't indexed: add the line to OPEN-STOPS.
 - If OPEN-STOPS lists a STOP that was actually resolved: append the
-  `→ resolved` follow-up to the original journal entry (date the review
+  `→ resolved` follow-up to the original record entry (date the review
   if unclear when), then remove the OPEN-STOPS line.
 - If a "STOP" entry is ambiguous (was it a real STOP or just a
   judgment?), surface it; don't guess.
@@ -160,7 +160,7 @@ Retiring a criterion is a GOAL.md change — it requires the same
 line-by-line confirmation as `set` edits.
 
 - Don't delete; mark `RETIRED YYYY-MM-DD (reason)`. Keep the ID. Old
-  journal entries reference C2; if C2 disappears, the references break.
+  record entries reference C2; if C2 disappears, the references break.
 - Add a Revisions line: `- YYYY-MM-DD: retired C<N> (reason)`.
 
 ### 4.3 Naked verdict followup
@@ -168,7 +168,7 @@ line-by-line confirmation as `set` edits.
 Don't retroactively edit old entries to add evidence — that's
 fabrication. Instead:
 
-- Note the issue in the next journal entry's Observations.
+- Note the issue in the next record entry's Observations.
 - Tighten the protocol: agent re-reads SKILL.md's evidence rule and
   states: "I'll be stricter about evidence going forward."
 - If a specific verdict was clearly wrong (e.g., "C2 ✓" three weeks ago
@@ -177,11 +177,11 @@ fabrication. Instead:
 
 ### 4.4 Rotation fix
 
-If May entries are in `journal-2026-04.md`:
+If May entries are in `record-2026-04.md`:
 - Move them to the correct file (cut from April, paste into a new
   May file).
 - Add a carry-over entry at the top of May.
-- Note in the review's own journal entry that rotation was missed.
+- Note in the review's own record entry that rotation was missed.
 
 ### 4.5 GOAL.md inconsistency
 
@@ -196,9 +196,9 @@ Type B, options for the human, wait for decision. The fact that the
 candidate came from review, not the per-session loop, doesn't change
 how it's resolved.
 
-### 4.7 Review's own journal entry
+### 4.7 Review's own record entry
 
-Review always logs a journal entry summarizing what was found and what
+Review always logs a record entry summarizing what was found and what
 was applied:
 
 ```markdown
@@ -216,7 +216,7 @@ the last one happened and what state it left things in.
 
 ### 4.8 Commit
 
-If files changed (OPEN-STOPS, GOAL.md, journals), commit them as one:
+If files changed (OPEN-STOPS, GOAL.md, records), commit them as one:
 "goal-driven: review YYYY-MM-DD — <one-line summary>".
 
 ## What review is NOT

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -75,7 +75,7 @@ to observe it is decoration; either find a proxy or cut it.
 
 Number criteria stably as `C1, C2, C3, ...`. **IDs are never reused** —
 if C2 is later retired, C2 stays as retired in GOAL.md; new ones become
-C5, C6. This keeps old journal entries' references resolvable.
+C5, C6. This keeps old record entries' references resolvable.
 
 Echo each criterion back with its measurement, one at a time, before
 adding the next.
@@ -133,7 +133,7 @@ final read catches typos and ordering issues, not substance.
 If missing (idempotent — skip what's already there):
 
 - `goals/` directory
-- `goals/journal.md` (single journal file, heading only)
+- `goals/record.md` (single record file, heading only)
 
 Don't create `OPEN-STOPS.md` or monthly-rotation files now; they're
 added later when project volume or open-STOP count makes them
@@ -160,10 +160,10 @@ When working on this initiative, follow the goal-driven protocol:
 
 - At session start, read `goals/GOAL.md` and surface any open STOPs
   (from `OPEN-STOPS.md` if it exists, otherwise by scanning recent
-  journal entries). If the project uses monthly journals, ensure the
+  record entries). If the project uses monthly records, ensure the
   current month's file exists; on rollover, propose a carry-over entry
   in chat before appending.
-- At session end, draft a journal entry in chat (what done, observations,
+- At session end, draft a record entry in chat (what done, observations,
   per-criterion check with evidence, judgment) and get confirmation
   before appending.
 - If a criterion verdict is `✗`, or new evidence questions the north
@@ -182,9 +182,9 @@ This is opt-in and rarely necessary; the skill description usually
 carries enough weight on its own. If the human asks for it, the harness
 or hookify skill can generate the config.
 
-### 4.3 First journal entry
+### 4.3 First record entry
 
-Add a "kickoff" entry to the journal. Format:
+Add a "kickoff" entry to the record. Format:
 
 ```markdown
 ## YYYY-MM-DD — Kickoff
@@ -194,17 +194,17 @@ Add a "kickoff" entry to the journal. Format:
 - Judgment: no change. Next session begins real work.
 ```
 
-This anchors the journal so the next session has something to read.
+This anchors the record so the next session has something to read.
 
 ### 4.4 Commit
 
 Commit `goals/`, agent config updates, and any hook configs together as
 the goal-driven setup. One commit, clear message: "goal-driven: set
-GOAL.md and journal scaffolding".
+GOAL.md and record scaffolding".
 
 ### 4.5 Tell the human what's next
 
-- The compass is set. From now on, every work session ends with a journal
+- The compass is set. From now on, every work session ends with a record
   entry the agent will draft and ask them to confirm.
 - If a criterion fails or the north star feels wrong, the agent will STOP
   and ask before continuing.

--- a/skills/goal-driven/references/example.md
+++ b/skills/goal-driven/references/example.md
@@ -1,7 +1,7 @@
 # Example walkthrough
 
 A concrete end-to-end run of goal-driven on one initiative, showing
-`set`, several journal entries, both STOP types, and resolution.
+`set`, several record entries, both STOP types, and resolution.
 
 The initiative: **adding semantic search to a chat application's history.**
 
@@ -75,9 +75,9 @@ I write that as a non-goal too, or note it as a stretch?"
 stretch goal, not required for success'."
 
 (Agent writes `goals/GOAL.md`, shows it in chat, gets final OK, adds
-kickoff entry to `journal-2026-04.md`.)
+kickoff entry to `record-2026-04.md`.)
 
-## journal-2026-04.md (early entries)
+## record-2026-04.md (early entries)
 
 ```markdown
 ## 2026-04-08 — Kickoff
@@ -143,7 +143,7 @@ kickoff entry to `journal-2026-04.md`.)
 (Posted to `OPEN-STOPS.md`:)
 
 ```
-- 2026-04-22 [Type A] C2 cold-start ambiguity → see journal-2026-04.md
+- 2026-04-22 [Type A] C2 cold-start ambiguity → see record-2026-04.md
 ```
 
 (Human picks option (a). GOAL.md is updated — C2 reworded with
@@ -209,5 +209,5 @@ reference.)
   Old IDs aren't reused. The Revisions section gives a quick scan of
   how the goal evolved.
 - **STOPs are not silent.** The agent surfaces them in chat, posts to
-  OPEN-STOPS, and waits. Resolution updates both the journal entry
+  OPEN-STOPS, and waits. Resolution updates both the record entry
   (append `→ resolved`) and OPEN-STOPS (remove the line).

--- a/skills/goal-driven/references/templates.md
+++ b/skills/goal-driven/references/templates.md
@@ -18,7 +18,7 @@ activity. Avoid "build X" — say what X enables.
 ## Success criteria
 Each criterion has a stable ID (C1, C2, ...). IDs are never reused. When a
 criterion is retired, mark it `RETIRED YYYY-MM-DD (reason)` but leave the
-line in place — old journal entries reference it.
+line in place — old record entries reference it.
 
 - **C1** — <falsifiable statement, with how it's measured>
 - **C2** — <falsifiable statement, with how it's measured>
@@ -54,7 +54,7 @@ human readability).
 Keep total length under ~80 lines. If GOAL.md grows past that, the goal
 is probably too compound — split into separate initiatives.
 
-## Journal entry
+## Record entry
 
 Each work session ends with one entry. Format:
 
@@ -83,7 +83,7 @@ Rules:
 
 ## STOP entry
 
-A STOP is just a journal entry with a STOP marker. Two flavors:
+A STOP is just a record entry with a STOP marker. Two flavors:
 
 ```markdown
 ## YYYY-MM-DD — STOP [Type A] C<N> failing — <one-line summary>
@@ -133,10 +133,10 @@ the latest. Reading top-to-bottom, the entry tells the story.
 ```markdown
 # Open STOPs
 
-Index of unresolved STOPs across all journals. Maintained by agent.
+Index of unresolved STOPs across all records. Maintained by agent.
 
-- 2026-05-02 [Type B] north star questioned by user feedback → see journal-2026-05.md
-- 2026-04-27 [Type A] C2 violated 3rd time this month → see journal-2026-04.md
+- 2026-05-02 [Type B] north star questioned by user feedback → see record-2026-05.md
+- 2026-04-27 [Type A] C2 violated 3rd time this month → see record-2026-04.md
 ```
 
 If empty:
@@ -166,7 +166,7 @@ event):
 ```
 
 This anchors the new file so the next session has context within the
-current month's journal alone.
+current month's record alone.
 
 ## Carry-over GOAL revision (after resolved STOP)
 


### PR DESCRIPTION
## Why

Follow-up to #1. The `journal-YYYY-MM.md` filename pattern reads awkwardly — the dash between word and date creates a visual stutter. More importantly, "journal" doesn't quite match what these files contain.

| | Stream-of-events | Reflective entries | Structured records |
|---|---|---|---|
| **log** | ✓ | | |
| **journal** | | ✓ | |
| **record** | | | ✓ |

The entries in goal-driven are structured (criteria check with evidence, judgment, principal tension) and append-only — closer to "record" than to "log" or "journal". The append-only semantics in particular: a record, once written, is appended to but not edited; that matches our protocol exactly.

## What changed

File names:
- `goals/journal.md` → `goals/record.md` (single-file mode, default)
- `goals/journal-YYYY-MM.md` → `goals/record-YYYY-MM.md` (after rotation)
- `goals/journal-archive/` → `goals/record-archive/`

Prose: `journal` references in the docs also updated to `record` for consistency. SKILL.md's intro phrasing was reworked to avoid the literal-substitution redundancy "the record is the living record".

No behavioral changes — same protocol, same templates, same commands.

## Test plan

- [x] No `journal` references remain (`grep -ri journal skills/goal-driven/` returns clean)
- [ ] No prose awkwardness from the substitution (spot-checked SKILL.md, commands/, references/)
- [ ] No broken cross-references between files

https://claude.ai/code/session_01Ropbiwjy8sEKSW1s7R2PXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ropbiwjy8sEKSW1s7R2PXP)_