### PR TITLE
design-driven: tighten Build/Verify discipline (State + falsifiability)

### DIFF
--- a/skills/design-driven/SKILL.md
+++ b/skills/design-driven/SKILL.md
@@ -203,14 +203,26 @@ blueprint alone. If a task blows past either, split it.
 
 **Build** — Code freely within design/ boundaries, following the blueprint's 
 approach. Check off TODO items as you go. If you discover a better approach 
-mid-build, update the blueprint first, then continue. Update the State 
-section with decisions made and current progress, so work can resume if 
-the session is interrupted. When a build-time decision is borderline 
-(technically 70% but not obvious), log it in State so review can catch it.
+mid-build, update the blueprint first, then continue. **Each completed TODO 
+triggers a State update — immediately on check-off, not "as you go" 
+optionally.** State is the resumption surface; if the session dies between 
+TODO 4 and TODO 5, a fresh agent should be able to read State and pick up 
+at TODO 5 without inferring from code. When a build-time decision is 
+borderline (technically 70% but not obvious), log it in State so review 
+can catch it.
 
 **Verify** — Check the implementation against the verification criteria 
 defined in Plan. Confirm: does it stay within design/ boundaries? Is 
 the scope respected?
+
+Verification needs a *falsifiable* check, not a feeling. Automated tests 
+are the default — and TDD (write the failing test first, then the code 
+that makes it pass) is the strongest form when the task type allows. 
+Other forms are accepted when tests don't fit the work: a contract trace 
+that demonstrates the new behavior end-to-end, a manual checklist run 
+with evidence captured, a comparison against a known-good state. The 
+form depends on the task; the *falsifiability* doesn't. "Looks right to 
+me" isn't verification.
 
 A failing test (or an observation during verify) that reveals something 
 DESIGN.md doesn't account for is a **signal about design silence**, not 

--- a/skills/design-driven/SKILL.md
+++ b/skills/design-driven/SKILL.md
@@ -204,8 +204,8 @@ blueprint alone. If a task blows past either, split it.
 **Build** — Code freely within design/ boundaries, following the blueprint's 
 approach. Check off TODO items as you go. If you discover a better approach 
 mid-build, update the blueprint first, then continue. **Each completed TODO 
-triggers a State update — immediately on check-off, not "as you go" 
-optionally.** State is the resumption surface; if the session dies between 
+triggers a State update — immediately on check-off, rather than being 
+deferred or optional.** State is the resumption surface; if the session dies between 
 TODO 4 and TODO 5, a fresh agent should be able to read State and pick up 
 at TODO 5 without inferring from code. When a build-time decision is 
 borderline (technically 70% but not obvious), log it in State so review 

--- a/skills/design-driven/references/example.md
+++ b/skills/design-driven/references/example.md
@@ -102,7 +102,8 @@ arg (defaulting to no limit to preserve existing callers). Route
 and handler done; validation + test still ahead.
 ```
 
-Check off TODOs as you go.
+Check off TODOs as you go — each check-off triggers a State update, 
+even when progress is small. State is the resumption surface.
 
 ## Step 5 — Verify
 

--- a/skills/design-driven/references/templates.md
+++ b/skills/design-driven/references/templates.md
@@ -37,7 +37,8 @@ What's in / what's out for this task specifically.
 
 ## State                         ← Scaffolding — removed at close out
 Decisions made during build, current progress, and anything needed to 
-resume if the session is interrupted. Update this as you go.
+resume if the session is interrupted. **Update on every TODO check-off**, 
+not optionally — State is the resumption surface, useless if it lags.
 
 ## Follow-ups                    ← Kept after close out (if any)
 Items that got scope-shaved but remain worth doing. Names and one-line 


### PR DESCRIPTION
## Why

Outside feedback (via user) flagged that design-driven's 70% Build phase has insufficient discipline — agents writing 200 lines without running tests, State sections lagging behind work, "looks right to me" verification slipping through.

The dialectical read: the diagnosis is correct (real gap at the Build/Verify boundary), but most of the prescriptions (forced TDD, micro-tasks, cold subagents for coding, pre-commit hook gates) either break design-driven's 30/70 contract or belong in a separate execution-layer skill. This PR takes only the two fixes that fit cleanly inside design-driven without changing its core thesis.

## What changed

**SKILL.md Build phase.** State update changes from soft ("as you go") to hard ("on every TODO check-off"). The reasoning: State is the resumption surface; if a session dies between TODO 4 and TODO 5, an out-of-date State is worse than no State, because the next agent reads stale info as truth. Making this hard preserves the resumption guarantee blueprints are supposed to provide.

**SKILL.md Verify phase.** Explicit falsifiability requirement. Automated tests + TDD named as default and strongest form, *but other falsifiable forms accepted* when tests don't fit (contract trace, manual checklist with evidence captured, known-good comparison). "Looks right to me" rejected. This catches the most common failure (verification by vibe) without making TDD mandatory — design-driven still applies to domains where tests aren't the right tool.

**templates.md State section description.** Aligned with the new hard rule.

## What this PR explicitly does NOT do

- **No forced TDD across all builds.** TDD is recommended where applicable, not gated.
- **No micro-task fragmentation.** Blueprint TODO granularity unchanged (~10 items).
- **No cold subagents for coding.** Cold review remains for proposal review only.
- **No pre-commit hook mandates.** That's a tooling layer concern, not methodology.

If a project genuinely needs that level of build-time discipline, it likely wants a separate execution-layer skill — sibling to goal-driven and design-driven, not absorbed into either.

## Test plan

- [ ] Run a real Build phase under the new rules; confirm State stays current
- [ ] Verify a non-test-friendly task (e.g., docs change) can still pass Verify with a non-test falsifiable form

https://claude.ai/code/session_01Ropbiwjy8sEKSW1s7R2PXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ropbiwjy8sEKSW1s7R2PXP)_