### PR TITLE
goal-driven: rename north star → General Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of [agent skills](https://agentskills.io) — reusable methodology 
 |-------|---------|-------------|
 | [design-driven](skills/design-driven/SKILL.md) | `/design-driven` | Design-driven development methodology. The `design/` directory is the single source of architectural truth — read it before coding, update the design before changing the system's shape. |
 | [evidence-driven](skills/evidence-driven/SKILL.md) | `/evidence-driven` | Evidence-driven discipline overlay for the execution layer. Every claim of progress requires a falsifiable observation — TDD cycle as default, evidence-trail State updates, anti-cargo-cult guards. Pairs with design-driven for build-time rigor on production code. |
-| [goal-driven](skills/goal-driven/SKILL.md) | `/goal-driven` | Goal-driven methodology for strategy-layer initiatives where the destination is clearer than the path. `GOAL.md` is the stable compass (north star + falsifiable criteria); the record captures what was tried and whether each criterion is still served. Pairs with design-driven. |
+| [goal-driven](skills/goal-driven/SKILL.md) | `/goal-driven` | Goal-driven methodology for strategy-layer initiatives where the destination is clearer than the path. `GOAL.md` is the stable compass (the General Line + falsifiable criteria); the record captures what was tried and whether each criterion is still served. Pairs with design-driven. |
 | [harness](skills/harness/SKILL.md) | `/harness` | Agent harness architecture — structure a project's agent context across layers (L1 architecture → L2 design → L3 implementation) for effective AI-assisted development. |
 
 ## Which skill, when?

--- a/skills/design-driven/SKILL.md
+++ b/skills/design-driven/SKILL.md
@@ -74,7 +74,7 @@ rewritten next week. Most ongoing engineering work fits.
 **Signals during design-driven work that warrant another skill:**
 
 - A criterion in goal-driven keeps failing despite shape being right
-  → may be a goal-level question (criterion wrong, north star
+  → may be a goal-level question (criterion wrong, the General Line
   questioned), not a design issue. Surface as a goal STOP.
 - "Verified" bugs still ship → build-time discipline gap; layer
   evidence-driven over the Build/Verify phase via

--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-driven
 description: |
   Goal-driven methodology for initiatives where the destination is clearer
-  than the path. GOAL.md is the stable compass — north star plus falsifiable
+  than the path. GOAL.md is the stable compass — the General Line plus falsifiable
   success criteria. The record captures what was tried, what was observed,
   and whether each criterion is still served. The agent writes both files;
   the human approves edits via chat.
@@ -96,7 +96,7 @@ training plans with concrete metrics. Concrete misfits: anything where
 ```
 project/
 └── goals/
-    ├── GOAL.md                  ← Stable compass (north star, criteria, invariants)
+    ├── GOAL.md                  ← Stable compass (General Line, criteria, invariants)
     ├── OPEN-STOPS.md            ← Index of unresolved STOP signals
     ├── record-2026-04.md       ← Past month
     └── record-2026-05.md       ← Current month (auto-rotates monthly)
@@ -116,7 +116,7 @@ last week, what worked, what didn't.
 The path mutates constantly. The compass mutates only when:
 
 - A success criterion turns out to be the wrong measure (replace it)
-- The north star itself is questioned by new evidence (rethink it)
+- The General Line itself is questioned by new evidence (rethink it)
 
 Both are deliberate, human-approved events. They are NOT what happens when
 "I tried X and it didn't work, let me try Y" — that's just walking.
@@ -156,7 +156,7 @@ intervenes at exactly those moments. Outside them, normal work.
 The agent interviews the human via chat. It does **not** draft GOAL.md
 alone and present it for review. It asks, in order:
 
-1. **North star** — "In one or two sentences, what should be true when
+1. **General Line** — "In one or two sentences, what should be true when
    this is done?"
 2. **Success criteria** — for each thing implied: "How would you know
    that's achieved?" Push for falsifiable; if soft, push for a proxy
@@ -238,13 +238,13 @@ trajectory already shows wastes that room.
   - (b) Change criterion (require human-approved GOAL edit)
   - (c) Agent misjudged
 
-**Type B — North star questioned.**
+**Type B — General Line questioned.**
 Criteria are met (or close), but new evidence suggests the goal itself
 solves the wrong problem.
 - Example: criteria all green, but user research reveals users wanted
   topic clustering, not semantic search.
 - Agent surfaces in chat, proposes:
-  - (a) Reframe north star (deliberate GOAL edit)
+  - (a) Reframe the General Line (deliberate GOAL edit)
   - (b) Stay course because the evidence is weak
 
 **Critical:** STOPs are never silently logged and walked past. The agent
@@ -318,7 +318,7 @@ Each story is a topic-named markdown file (kebab-case). Typical topics:
 - Why a specific criterion is set as it is, including data or context
   that informed the number or threshold
 - What an ambiguous term in GOAL.md means in practice
-- Background on the choice of north star — what alternatives were
+- Background on the choice of General Line — what alternatives were
   considered, why this framing won
 - Trade-offs explicitly accepted (what you're giving up to chase this)
 - How understanding of a criterion has evolved through STOPs and

--- a/skills/goal-driven/commands/review.md
+++ b/skills/goal-driven/commands/review.md
@@ -96,7 +96,7 @@ happened wrong or not at all.
 
 **GOAL.md contradicting itself.** Read end-to-end as if you'd never seen
 it. Look for criteria conflicting with each other, invariants conflicting
-with criteria, non-goals contradicting the north star, recent edits
+with criteria, non-goals contradicting the General Line, recent edits
 that didn't make it into Revisions. The skill assumes GOAL.md is
 internally consistent because it changes rarely; once that assumption
 breaks, every later criteria check is judging against confused targets.

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -205,7 +205,7 @@ candidates:
 - A criterion whose number / threshold deserves explaining
 - A non-goal that's tempting to revisit later (story explains why we
   said no the first time)
-- A General Line phrasing that took multiple iterations to land on
+- A phrasing of the General Line that took multiple iterations to land on
 - An invariant whose cost we explicitly accepted
 
 Propose **at most one** — the highest-value candidate. The human

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -43,7 +43,7 @@ matters and *what good answers look like*. The interview's value is the
 human's commitment to the wording — a draft the agent wrote and the
 human nodded at is not the same as a wording they confirmed.
 
-### 2.1 North star — what should be true when this is done
+### 2.1 General Line — what should be true when this is done
 
 Extract one or two sentences describing the world-state at success, not
 the activity that produces it. The exact phrasing matters: every future
@@ -189,7 +189,7 @@ Add a "kickoff" entry to the record. Format:
 ```markdown
 ## YYYY-MM-DD — Kickoff
 - What I did: established GOAL.md via interview.
-- Observations: north star confirmed; <N> success criteria; <M> invariants.
+- Observations: General Line confirmed; <N> success criteria; <M> invariants.
 - Criteria check: all unclear — no work done yet.
 - Judgment: no change. Next session begins real work.
 ```
@@ -205,7 +205,7 @@ candidates:
 - A criterion whose number / threshold deserves explaining
 - A non-goal that's tempting to revisit later (story explains why we
   said no the first time)
-- A north star phrasing that took multiple iterations to land on
+- A General Line phrasing that took multiple iterations to land on
 - An invariant whose cost we explicitly accepted
 
 Propose **at most one** — the highest-value candidate. The human
@@ -239,7 +239,7 @@ GOAL.md and record scaffolding".
 
 - The compass is set. From now on, every work session ends with a record
   entry the agent will draft and ask them to confirm.
-- If a criterion fails or the north star feels wrong, the agent will STOP
+- If a criterion fails or the General Line feels wrong, the agent will STOP
   and ask before continuing.
 - They don't need to remember any of this — the agent's protocol carries
   it. Their job is to approve, redirect, and decide at STOPs.

--- a/skills/goal-driven/references/example.md
+++ b/skills/goal-driven/references/example.md
@@ -13,7 +13,7 @@ done?"
 **Human:** "Users can find old conversations by meaning, not just exact
 keyword."
 
-**Agent:** "Got it. I'll write the north star as: *Users can locate
+**Agent:** "Got it. I'll write the General Line as: *Users can locate
 conversations from the last three months by meaning, without needing exact
 keywords.* OK?"
 
@@ -208,7 +208,7 @@ Audit trail follows:)
 After several more weeks of work, the feature ships to 5% of users:
 
 ```markdown
-## 2026-05-02 — STOP [Type B] north star may be wrong
+## 2026-05-02 — STOP [Type B] General Line may be wrong
 - What I did: interviewed three heavy users about how they're using the
   new search.
 - Observations: All three said they rarely use semantic search. What
@@ -223,7 +223,7 @@ After several more weeks of work, the feature ships to 5% of users:
   shape of help. Continuing to optimize semantic search may be local
   optimization on the wrong problem.
 - Options for human:
-  - (a) Reframe north star toward topic clustering. Existing semantic
+  - (a) Reframe the General Line toward topic clustering. Existing semantic
     search becomes substrate, not the product.
   - (b) Stay course — three users is a small sample; ship to more
     before redirecting.
@@ -233,7 +233,7 @@ After several more weeks of work, the feature ships to 5% of users:
 (Human picks (b) — wants more data before pivoting. Two weeks later,
 broader rollout shows the same pattern. STOP is reopened — agent surfaces
 again, this time the human picks (a). GOAL is rewritten under the new
-north star, criteria are revised; old criteria are RETIRED but kept for
+General Line, criteria are revised; old criteria are RETIRED but kept for
 reference.)
 
 After the reframe, the agent proposes a story update:
@@ -261,7 +261,7 @@ revision alone wouldn't carry.
   (criterion can't be met as stated). 2026-05-02 is goal failure
   (criteria met, but the goal solves the wrong problem). The
   resolutions look very different — Type A often gets fixed by tightening
-  a criterion; Type B requires rethinking the north star.
+  a criterion; Type B requires rethinking the General Line.
 - **GOAL.md changes are deliberate events.** Every revision is logged.
   Old IDs aren't reused. The Revisions section gives a quick scan of
   how the goal evolved.

--- a/skills/goal-driven/references/templates.md
+++ b/skills/goal-driven/references/templates.md
@@ -11,7 +11,7 @@ these files.
 > One sentence: what this is. The reader should know in 10 seconds whether
 > this initiative is theirs to care about.
 
-## North star
+## General Line
 One or two sentences. The world-state when this is done. Outcome, not
 activity. Avoid "build X" — say what X enables.
 
@@ -101,17 +101,17 @@ A STOP is just a record entry with a STOP marker. Two flavors:
 - Status: open
 ```
 
-Type B (north star questioned):
+Type B (General Line questioned):
 
 ```markdown
-## YYYY-MM-DD — STOP [Type B] north star may be wrong — <one-line>
+## YYYY-MM-DD — STOP [Type B] General Line may be wrong — <one-line>
 - What I did: <whatever surfaced the doubt>
 - Observations: <new evidence>
 - Criteria check: <usually all ✓ or close>
 - Judgment: STOP Type B. Criteria served, but the goal itself may not
   matter as stated.
 - Options for human:
-  - (a) Reframe north star (deliberate GOAL change)
+  - (a) Reframe the General Line (deliberate GOAL change)
   - (b) Stay course — evidence is too weak to redirect
 - Status: open
 ```
@@ -135,7 +135,7 @@ the latest. Reading top-to-bottom, the entry tells the story.
 
 Index of unresolved STOPs across all records. Maintained by agent.
 
-- 2026-05-02 [Type B] north star questioned by user feedback → see record-2026-05.md
+- 2026-05-02 [Type B] General Line questioned by user feedback → see record-2026-05.md
 - 2026-04-27 [Type A] C2 violated 3rd time this month → see record-2026-04.md
 ```
 


### PR DESCRIPTION
## Summary

Rename `north star` to **the General Line** throughout the goal-driven skill. Soviet planning vocabulary fits the Chinese-style strategic register better than the American-navigation metaphor, while carrying the same role: the unifying top-level objective that GOAL.md is built around.

- 5 files, 22 occurrences (SKILL.md, set.md, review.md, templates.md, example.md)
- `compass` metaphor preserved — it's the artifact role; `General Line` is what the compass points at, so the two layer cleanly rather than competing
- No other Soviet terms (`operational art`, `directive`, `main effort`) introduced — the rename is light vocabulary substitution, not a methodology framework rebuild

## Why this register

Discussion: `North Star` reads as American-navigation flavor; for a goal-driven methodology that pairs with `design-driven` and is used in Chinese strategic-planning contexts (主线/总路线/总纲), `the General Line` carries the right top-down, programmatic, hierarchical association. It's the established English equivalent of 总路线 and entered the language through serious strategy writing, so it's recognizable without explanation.

## Test plan

- [ ] Read SKILL.md end-to-end — does `the General Line` read naturally everywhere it appears?
- [ ] Spot-check `commands/set.md` §2.1 — does the interview script still flow?
- [ ] Spot-check `references/example.md` STOP Type B — does the dialog still make sense?

🤖 Generated with [Claude Code](https://claude.com/claude-code)