### PR TITLE
goal-driven: reframe non-goals as forbidden zones

### DIFF
--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -162,7 +162,10 @@ alone and present it for review. It asks, in order:
    that's achieved?" Push for falsifiable; if soft, push for a proxy
    indicator.
 3. **Invariants** — "What must stay true regardless of how we get there?"
-4. **Non-goals** — "What's tempting to call success but isn't?"
+4. **Non-goals** — "What's tempting but explicitly out of scope? What
+   would an outsider lobby for that we've already decided against, and
+   why?" Push back if a candidate is just an inverted goal — non-goals
+   are forbidden zones, not goals restated in the negative.
 
 The agent **echoes each section back as it's drafted**, gets confirmation,
 moves on. GOAL.md is written only after all sections are confirmed. See

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -97,20 +97,61 @@ doesn't drop").
 
 Past 4 invariants, some are probably criteria or non-goals in disguise.
 
-### 2.4 Non-goals — what's tempting but isn't success
+### 2.4 Non-goals — the forbidden zones
 
-Extract the things the human will be tempted to call success later but
-explicitly aren't. Common patterns:
+Non-goals draw a perimeter: types of work that, even when tempting, this
+initiative will not pursue. They are **scope boundaries, not inverted
+goals.** The job of a non-goal is to pre-empt scope creep — when someone
+later argues "but it would be *great* if we also did X", the non-goal is
+the answer that has already been thought through.
 
-- Possible "phase 2" features — name as non-goals, not delayed goals
-- Adjacent improvements the team will be tempted to make along the way
-- Metrics that will rise as a side effect but aren't the point
+**The single most common failure: non-goals that are just goals
+restated in the negative.** "We want fast search → non-goal: slow
+search." That delimits nothing — nothing realistic was tempting in that
+direction. A real non-goal names *something an honest reviewer might
+lobby for* and then declines it, with a reason.
+
+Pressure-test each candidate with this question: *"If we did this,
+would we be doing the **wrong work**, or just **less of the right
+work**?"* Wrong-work items belong in non-goals. Less-of-the-right items
+belong in prioritization or as stretch notes — not in GOAL.md.
+
+Anti-pattern → fix:
+
+- "Don't ship a buggy product" — inverted goal; cut.
+- "Not for casual users" — too abstract. Turn it into a forbidden
+  scope: "No beginner onboarding flow this round; ships only for users
+  who already know the domain."
+- "Avoid scope creep" — meaningless. Name the specific creep: "No
+  generic policy platform across BUs — this initiative ships for one
+  BU's needs only."
+
+Common shapes that produce real non-goals:
+
+- **Adjacent platforms tempting to re-implement.** "We don't build our
+  own agent runtime — we integrate with existing frameworks." A
+  reviewer who thinks runtime ownership matters hits this line and
+  knows the trade-off was already weighed.
+- **Adjacent users we won't serve in this iteration.** "No multi-tenant
+  isolation; single-tenant only this round."
+- **Possible 'phase 2' features that will get lobbied for.** Name as
+  non-goals, not 'later goals'. 'Later' converges with 'now' under
+  pressure; 'forbidden, with a reason' doesn't.
+- **Metrics / outcomes that will rise as side effects.** Don't pretend
+  they're the goal: "Not optimizing for DAU — retention is the target;
+  DAU may move but isn't measured."
+- **Replacing systems we should integrate with.** "We don't rewrite
+  CRM/ticketing/IM — only integrate via tools."
 
 Most humans first say they don't have any non-goals. They do; they just
-haven't named them. Prompt with the patterns above until something
-lands.
+haven't named them. Prompt with: *"Is there work an outsider would
+suggest you should also do, that you've already decided against? Why?"*
+Then run candidates through the wrong-work / less-of-right test before
+accepting them.
 
-Echo each non-goal back; confirm.
+Echo each non-goal back **with the reason it's out of scope**, not just
+the name; confirm. A non-goal without a reason rots into a question mark
+the next time someone lobbies for it.
 
 ## Phase 3 — Draft
 
@@ -266,3 +307,8 @@ all 8 simultaneously, the goal is too compound — split or reframe.
 They do; they just haven't named them. Prompt with: "What did you almost
 include but decided to leave out? What would be a sign of scope creep
 later?"
+
+**Accepting inverted goals as non-goals.** "We want X → non-goal: not
+X" delimits nothing. If a non-goal candidate doesn't name a specific
+*tempting* path the initiative declines, it isn't doing the work of a
+non-goal. Push for a forbidden zone with a reason, or cut the line.

--- a/skills/goal-driven/references/example.md
+++ b/skills/goal-driven/references/example.md
@@ -60,19 +60,34 @@ existing keyword search API contract is unchanged*. OK?"
 
 **Human:** "Yes."
 
-**Agent:** "What's tempting to call success but isn't?"
+**Agent:** "What's tempting but explicitly out of scope — work an
+outside reviewer might lobby for that you've already decided against?"
 
 **Human:** "Cross-user search would be cool but is out. And multi-language
 — Chinese only for now, English nice-to-have but not blocking."
 
-**Agent:** "Non-goals: *cross-user search*; *multi-language beyond
-Chinese*. English support is desired but not required for success — should
-I write that as a non-goal too, or note it as a stretch?"
+**Agent:** "For each, the reason matters — it's what stops the line
+from rotting into a question mark next time someone lobbies. Why
+cross-user search out?"
+
+**Human:** "Privacy review would balloon scope; this is single-user
+search inside one's own history."
+
+**Agent:** "And multi-language beyond Chinese?"
+
+**Human:** "Embedding model trade-offs differ by language. Pinning to
+Chinese keeps the model choice simple."
+
+**Agent:** "Non-goals captured as: *cross-user search — privacy review
+would expand scope beyond a single user's own history*; *multi-language
+beyond Chinese — keeps embedding model choice simple, avoids
+per-language tuning*. English support is desired but not required —
+should I write that as a non-goal or note it as a stretch?"
 
 **Human:** "Note as stretch — don't make it a non-goal."
 
-**Agent:** "Got it. I'll add a note under Non-goals: 'English support is a
-stretch goal, not required for success'."
+**Agent:** "Got it. I'll add a note under Non-goals: 'English support
+is a stretch goal, not required for success'."
 
 (Agent writes `goals/GOAL.md`, shows it in chat, gets final OK, adds
 kickoff entry to `record-2026-04.md`.)

--- a/skills/goal-driven/references/templates.md
+++ b/skills/goal-driven/references/templates.md
@@ -37,10 +37,14 @@ signal even if criteria are on track.
 0–4 invariants is typical.
 
 ## Non-goals
-What's tempting to call success but isn't. The defense against scope creep.
+Forbidden zones — types of work that, even when tempting, this
+initiative declines. Each line names a specific *tempting* path and the
+reason it's out of scope. Not inverted goals ("don't ship slow
+search" delimits nothing). Test: would an honest reviewer ever lobby
+for this? If no, it's not a non-goal worth listing.
 
-- <non-goal 1>
-- <non-goal 2>
+- <forbidden zone 1> — <one-line reason>
+- <forbidden zone 2> — <one-line reason>
 
 ## Revisions
 Lightweight log of GOAL.md changes (git has the full diff; this is for


### PR DESCRIPTION
## Summary

Agents producing GOAL.md often emit non-goals that are just goals restated in the negative ("we want fast → don't be slow"), which delimits nothing. The interview now pushes for **forbidden zones**: specific tempting paths the initiative declines, each with a reason.

## Changes

- **`commands/set.md` §2.4** — rewritten with the *wrong-work vs. less-of-the-right-work* test, an anti-pattern → fix list, and concrete shapes that produce real non-goals (adjacent platforms, adjacent users, "phase 2" features, side-effect metrics, systems we should integrate with rather than rewrite). Each non-goal must carry a reason.
- **`commands/set.md` failure modes** — adds "Accepting inverted goals as non-goals" as a named failure mode.
- **`SKILL.md` Moment 1** — tightens the non-goal interview question with the forbidden-zone framing.
- **`references/templates.md`** — clarifies the Non-goals section and changes the bullet form to `<forbidden zone> — <one-line reason>`.
- **`references/example.md`** — extends the example interview to model asking *why* each non-goal is out of scope.

## Test plan

- [ ] Run `/goal-driven set` against a fresh initiative and verify the agent now pushes back on inverted-goal candidates.
- [ ] Confirm the produced GOAL.md contains non-goals with reasons attached.
- [ ] Skim the example walkthrough to ensure the interview reads naturally with the new prompts.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FmHKh6npPPenV8cY5YBxu)_