### PR TITLE
goal-driven: idempotent set + sibling-aware CLAUDE.md block (init pilot)

### DIFF
--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -47,10 +47,10 @@ When invoked with an argument, dispatch to the corresponding file:
 
 - `/goal-driven set` → Read and follow `commands/set.md`.
   First run: interview the human and produce the initial GOAL.md,
-  plus scaffolding. Re-run: update mode — refreshes the CLAUDE.md
-  agent-config block (including cross-references to sibling skills
-  installed since), re-checks plumbing. Doesn't re-interview the
-  goal; for re-assessment use `review`.
+  plus scaffolding. Re-run: update mode — refreshes the agent-config
+  blocks (including cross-references to sibling skills installed
+  since), re-checks plumbing. Doesn't re-interview the goal; for
+  re-assessment use `review`.
 - `/goal-driven review` → Read and follow `commands/review.md`.
   Strategic checkpoint plus protocol maintenance: re-assess where the
   project stands against GOAL, surface drift, propose corrections.
@@ -62,8 +62,8 @@ When invoked with an argument, dispatch to the corresponding file:
 **Which command when:**
 
 - New initiative → `set`
-- A sibling skill was installed/removed and CLAUDE.md cross-references
-  feel stale → `set` again (update mode; no re-interview)
+- A sibling skill was installed/removed and agent-config cross-
+  references feel stale → `set` again (update mode; no re-interview)
 - ≥ 2 weeks since last review, record feels overgrown, midpoint of an
   explicit timeline, or you sense you've drifted → `review`
 - Initiative is done, abandoned, or superseded → `close`

--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -162,7 +162,10 @@ alone and present it for review. It asks, in order:
    that's achieved?" Push for falsifiable; if soft, push for a proxy
    indicator.
 3. **Invariants** — "What must stay true regardless of how we get there?"
-4. **Non-goals** — "What's tempting to call success but isn't?"
+4. **Non-goals** — "What's tempting but explicitly out of scope? What
+   would an outsider lobby for that we've already decided against, and
+   why?" Push back if a candidate is just an inverted goal — non-goals
+   are forbidden zones, not goals restated in the negative.
 
 The agent **echoes each section back as it's drafted**, gets confirmation,
 moves on. GOAL.md is written only after all sections are confirmed. See

--- a/skills/goal-driven/SKILL.md
+++ b/skills/goal-driven/SKILL.md
@@ -46,8 +46,11 @@ or future-you — pick up a months-long initiative without losing direction.
 When invoked with an argument, dispatch to the corresponding file:
 
 - `/goal-driven set` → Read and follow `commands/set.md`.
-  Interview the human and produce the initial GOAL.md, plus minimal
-  scaffolding. Run once per initiative.
+  First run: interview the human and produce the initial GOAL.md,
+  plus scaffolding. Re-run: update mode — refreshes the CLAUDE.md
+  agent-config block (including cross-references to sibling skills
+  installed since), re-checks plumbing. Doesn't re-interview the
+  goal; for re-assessment use `review`.
 - `/goal-driven review` → Read and follow `commands/review.md`.
   Strategic checkpoint plus protocol maintenance: re-assess where the
   project stands against GOAL, surface drift, propose corrections.
@@ -59,6 +62,8 @@ When invoked with an argument, dispatch to the corresponding file:
 **Which command when:**
 
 - New initiative → `set`
+- A sibling skill was installed/removed and CLAUDE.md cross-references
+  feel stale → `set` again (update mode; no re-interview)
 - ≥ 2 weeks since last review, record feels overgrown, midpoint of an
   explicit timeline, or you sense you've drifted → `review`
 - Initiative is done, abandoned, or superseded → `close`

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -1,47 +1,82 @@
 # goal-driven:set — Interview-driven GOAL.md
 
-Create the initial `goals/GOAL.md` by interviewing the human, and set up
-the minimal scaffolding around it. Run once per initiative — when
-adopting goal-driven on a project that doesn't have one yet, or when
-re-setting after a major change in direction.
+Create or refresh `goals/GOAL.md` and the plumbing around it. The
+interview is the heart of the first run; subsequent runs are
+**update mode** — refreshing scaffolding, sibling integration, and
+the CLAUDE.md block without re-interviewing for the goal itself.
 
-The interview is the whole point. Do **not** draft GOAL.md alone in your
-head, ask "approve?", and write the file. Section by section, asking,
-echoing, getting confirmation, then moving on. The point is that the human
-ends up owning the compass — the agent is the writer, not the author.
+The interview is the whole point on first run. Do **not** draft GOAL.md
+alone in your head, ask "approve?", and write the file. Section by
+section, asking, echoing, getting confirmation, then moving on. The point
+is that the human ends up owning the compass — the agent is the writer,
+not the author.
 
-Work in four phases: **Prepare → Interview → Draft → Wire up**.
+Work in four phases: **Prepare → Interview → Draft → Wire up**. In
+update mode, skip Phase 2 and Phase 3 (GOAL.md already exists and stays
+human-owned); run Phase 1 detection and Phase 4 wire-up only.
 
 ## Phase 1 — Prepare
 
-### 1.1 Check current state
+### 1.1 Detect run mode
 
-If `goals/GOAL.md` already has non-stub content, stop and ask the human:
+Look at `goals/GOAL.md`:
 
-- "There's already content in `goals/GOAL.md` — do you want to redo from
-  scratch (I'll archive the current one), or did you mean
-  `/goal-driven review` to step back and re-assess?"
+- **First-run** — file missing or only stub content. Run all four
+  phases. Tell the human: "Setting up goal-driven for the first time;
+  I'll interview you for the goal."
+- **Update** — file exists with real content. Tell the human: "Goal
+  already set; re-running `set` will refresh the scaffolding, sibling
+  integration, and CLAUDE.md block — won't touch GOAL.md or records.
+  Want a redo from scratch instead? (rare — usually `/goal-driven
+  review` is what you want for re-assessment.)"
 
-If they confirm redo: move existing `goals/GOAL.md` to
-`goals/GOAL.archived-YYYY-MM-DD.md` before continuing.
+  Default behavior in update mode: skip interview/draft phases, jump to
+  Phase 1.2 (sibling detection) → Phase 4 (wire-up). Only redo from
+  scratch if the human explicitly asks; if so, archive existing
+  `goals/GOAL.md` to `goals/GOAL.archived-YYYY-MM-DD.md` and proceed
+  as first-run.
 
-### 1.2 Surface what's already known
+### 1.2 Detect installed sibling skills
+
+Scan for sibling methodology skills already wired into this project. The
+results inform both the interview (Phase 2) and the CLAUDE.md block
+written in Phase 4.
+
+| Sibling | Detection signal |
+|---|---|
+| design-driven | `design/DESIGN.md` exists, OR CLAUDE.md contains `<!-- skill:design-driven -->` block |
+| evidence-driven | CLAUDE.md contains `<!-- skill:evidence-driven -->` block, OR pre-commit hook references evidence-driven |
+
+Note which siblings are present. No action yet — used in later phases.
+
+### 1.3 Surface what's already known
 
 If there's prior context — `README.md`, project notes, prior conversation,
-emails, an existing scratch document — read it. The interview is faster
-when the agent can ask "I see in your notes that X — is that the north
-star, or a means to it?" rather than starting blank.
+emails, an existing scratch document, and (especially) `design/DESIGN.md`
+if design-driven is installed — read it. The interview is faster when
+the agent can ask "I see in your notes / design that X — is that the
+north star, or a means to it?" rather than starting blank.
 
 If the project is new with no prior writing, skip this; start the
-interview from zero.
+interview from zero. (Update mode skips this section entirely.)
 
 ## Phase 2 — Interview
+
+(First-run only. Skip in update mode.)
 
 Four sections, drawn out one at a time and confirmed before moving on.
 Phrasing is the agent's; the descriptions below are *why* each section
 matters and *what good answers look like*. The interview's value is the
 human's commitment to the wording — a draft the agent wrote and the
 human nodded at is not the same as a wording they confirmed.
+
+**If design-driven is installed** (per Phase 1.2 detection), use
+`design/DESIGN.md` as the starting context — modules, invariants, and
+non-goals there are clues to the goal's shape. Don't import them
+verbatim; ask the human whether each is goal-level (compass) or
+shape-level (already owned by design-driven). The interview narrows
+faster when it can react to existing artifacts instead of starting
+blank.
 
 ### 2.1 General Line — what should be true when this is done
 
@@ -94,6 +129,14 @@ Common patterns to prompt with when the human draws a blank: data
 boundaries ("user data stays local"), process rules ("no weekends"),
 scope walls ("only contracted work"), quality floors ("test coverage
 doesn't drop").
+
+If design-driven is installed and `design/DESIGN.md` lists invariants
+or non-goals at the architecture layer, surface them: "DESIGN.md says
+*<invariant>* — should this also be a goal invariant, or is it
+purely shape-level?" Goal invariants are about the initiative's
+direction (the project must always X); design invariants are about
+the system's structure. Same words, different scope — keep them
+separate, but cross-check.
 
 Past 4 invariants, some are probably criteria or non-goals in disguise.
 
@@ -169,6 +212,12 @@ final read catches typos and ordering issues, not substance.
 
 ## Phase 4 — Wire up
 
+This phase runs in **both** first-run and update mode. It's idempotent:
+each step does nothing if state is already current, or refreshes
+otherwise. Re-running `/goal-driven set` on a project that's already set
+up is the supported way to refresh the CLAUDE.md block after siblings
+get installed or removed.
+
 ### 4.1 Ensure plumbing exists
 
 If missing (idempotent — skip what's already there):
@@ -180,21 +229,40 @@ Don't create `OPEN-STOPS.md` or monthly-rotation files now; they're
 added later when project volume or open-STOP count makes them
 load-bearing. See SKILL.md "Structure follows need."
 
-### 4.2 Update agent configs
+### 4.2 Write the agent-config block (idempotent)
 
-Append goal-driven instructions to every AI agent config the project
-uses. Common locations:
+Goal-driven owns a delimited block in every AI agent config file the
+project uses. The markers make the block re-runnable: on update, replace
+between the markers; on first run, append the block.
+
+**Marker convention:**
+
+```
+<!-- skill:goal-driven -->
+...content...
+<!-- /skill:goal-driven -->
+```
+
+**Where to write.** Common config locations — write only to those that
+already exist (don't create new agent configs for tools the project
+doesn't use):
 
 - `CLAUDE.md` — Claude Code
 - `.cursorrules` — Cursor
 - `AGENTS.md` or `codex.md` — Codex / OpenAI agents
 - `.github/copilot-instructions.md` — GitHub Copilot
 - `.windsurfrules` — Windsurf
-- Any other agent instruction file the project uses
 
-Minimal paste-ready snippet (trim or expand to match the project's tone):
+**Algorithm for each file.** If the file contains
+`<!-- skill:goal-driven -->`, replace everything between markers
+(inclusive of markers) with the new block. Otherwise, append the new
+block at the end (preceded by a blank line).
+
+**Block content** — base, plus a conditional Interactions section
+populated from Phase 1.2 detection:
 
 ```markdown
+<!-- skill:goal-driven -->
 ## Goal-driven planning
 
 When working on this initiative, follow the goal-driven protocol:
@@ -212,10 +280,29 @@ When working on this initiative, follow the goal-driven protocol:
   silently rewrite the path past a STOP.
 - Never edit `GOAL.md` without an explicit, confirmed change request
   from the human, echoed back line by line.
+
+### Interactions
+<!-- Only emit lines whose sibling was detected in Phase 1.2.
+     If no siblings detected, omit this whole subsection. -->
+
+- **with design-driven** (detected: `design/DESIGN.md` present) —
+  goal-driven owns *why* and *how-far*; design-driven owns
+  *what-shape*. A goal pivot that crosses module boundaries also
+  triggers a `design/decisions/NNN-*.md` proposal. A design proposal
+  that would violate a GOAL invariant triggers a Type A STOP first.
+  Cross-reference by ID, not content (record entry: "adopted
+  decision 003"; decision: "blocks STOP from 2026-05-02 if rejected").
+- **with evidence-driven** (detected: evidence-driven block in this
+  file) — every criterion ✓/✗ in record entries cites a falsifiable
+  observation. STOP signals that depend on build observations are
+  credible only when those observations carry evidence-driven trails.
+<!-- /skill:goal-driven -->
 ```
 
-Check which config files already exist; don't create files for tools the
-project doesn't use.
+**Show the block in chat before writing.** Especially in update mode —
+the human should see whether siblings were detected correctly. If a
+sibling is installed but wasn't detected (e.g., because it lives in an
+unusual path), the human can flag it before the write.
 
 A SessionStart hook can enforce the protocol mechanically — emit a
 reminder to read GOAL.md and surface open STOPs at every session start.
@@ -223,7 +310,27 @@ This is opt-in and rarely necessary; the skill description usually
 carries enough weight on its own. If the human asks for it, the harness
 or hookify skill can generate the config.
 
-### 4.3 First record entry
+### 4.3 Suggest sibling refresh
+
+After writing goal-driven's block, scan each detected sibling's block
+in the same agent-config files. If a sibling block exists but lacks any
+mention of goal-driven (or refers to it in a stale way), nudge — don't
+edit the sibling's block:
+
+> I refreshed `<!-- skill:goal-driven -->` to mention design-driven /
+> evidence-driven. Their own blocks may be out of date for the reverse
+> direction — re-running `/design-driven init` and `/evidence-driven
+> init` will refresh them with the latest cross-references. Want me to
+> do that now, or leave for later?
+
+If the human says yes, dispatch to those skills' init commands. If no
+or "later", that's fine — the cross-references are useful but not
+load-bearing.
+
+**Do not edit sibling blocks directly.** Each skill owns its block;
+goal-driven only writes between its own markers.
+
+### 4.4 First record entry (first-run only)
 
 Add a "kickoff" entry to the record. Format:
 
@@ -235,9 +342,10 @@ Add a "kickoff" entry to the record. Format:
 - Judgment: no change. Next session begins real work.
 ```
 
-This anchors the record so the next session has something to read.
+This anchors the record so the next session has something to read. In
+update mode, skip — record already has entries.
 
-### 4.4 Propose initial stories (opt-in)
+### 4.5 Propose initial stories (opt-in, first-run only)
 
 Look at the GOAL.md just written and ask: are there choices in here
 that future-you (or a future agent) would want context on? Typical
@@ -270,13 +378,21 @@ Don't push.
 
 See `references/templates.md` for the story file template.
 
-### 4.5 Commit
+### 4.6 Commit
 
-Commit `goals/`, agent config updates, and any hook configs together as
-the goal-driven setup. One commit, clear message: "goal-driven: set
-GOAL.md and record scaffolding".
+Commit `goals/`, agent config updates, and any hook configs together.
+One commit, clear message:
 
-### 4.6 Tell the human what's next
+- First-run: `goal-driven: set GOAL.md and record scaffolding`
+- Update: `goal-driven: refresh CLAUDE.md block (siblings: <list>)`
+
+If update mode produced no actual changes (block already current,
+plumbing already in place), skip the commit — empty commits add noise.
+Just report: "Re-run produced no changes; setup is already current."
+
+### 4.7 Tell the human what's next
+
+First-run:
 
 - The compass is set. From now on, every work session ends with a record
   entry the agent will draft and ask them to confirm.
@@ -284,6 +400,12 @@ GOAL.md and record scaffolding".
   and ask before continuing.
 - They don't need to remember any of this — the agent's protocol carries
   it. Their job is to approve, redirect, and decide at STOPs.
+
+Update:
+
+- Summarize what changed (e.g., "added evidence-driven cross-reference
+  to the goal-driven block").
+- Mention any sibling refreshes still pending (per Phase 4.3).
 
 ## Avoid these failure modes
 

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -39,13 +39,13 @@ Look at `goals/GOAL.md`:
 ### 1.2 Detect installed sibling skills
 
 Scan for sibling methodology skills already wired into this project. The
-results inform both the interview (Phase 2) and the CLAUDE.md block
+results inform both the interview (Phase 2) and the agent-config block
 written in Phase 4.
 
 | Sibling | Detection signal |
 |---|---|
-| design-driven | `design/DESIGN.md` exists, OR CLAUDE.md contains `<!-- skill:design-driven -->` block |
-| evidence-driven | CLAUDE.md contains `<!-- skill:evidence-driven -->` block, OR pre-commit hook references evidence-driven |
+| design-driven | `design/DESIGN.md` exists, OR any agent config file (see Phase 4.2 list) contains `<!-- skill:design-driven -->` block |
+| evidence-driven | Any agent config file (see Phase 4.2 list) contains `<!-- skill:evidence-driven -->` block, OR pre-commit hook references evidence-driven |
 
 Note which siblings are present. No action yet — used in later phases.
 
@@ -252,14 +252,19 @@ doesn't use):
 - `AGENTS.md` or `codex.md` — Codex / OpenAI agents
 - `.github/copilot-instructions.md` — GitHub Copilot
 - `.windsurfrules` — Windsurf
+- Any other agent instruction file the project uses
 
 **Algorithm for each file.** If the file contains
 `<!-- skill:goal-driven -->`, replace everything between markers
 (inclusive of markers) with the new block. Otherwise, append the new
 block at the end (preceded by a blank line).
 
-**Block content** — base, plus a conditional Interactions section
-populated from Phase 1.2 detection:
+**Block content** — base, plus a conditional Interactions subsection
+populated from Phase 1.2 detection. The template below shows the full
+block with both possible Interactions lines; **emit only the lines
+whose sibling was actually detected**, and omit the entire `### Interactions`
+heading if no siblings were detected. Do not copy the meta-instruction
+itself into the file.
 
 ```markdown
 <!-- skill:goal-driven -->
@@ -282,8 +287,6 @@ When working on this initiative, follow the goal-driven protocol:
   from the human, echoed back line by line.
 
 ### Interactions
-<!-- Only emit lines whose sibling was detected in Phase 1.2.
-     If no siblings detected, omit this whole subsection. -->
 
 - **with design-driven** (detected: `design/DESIGN.md` present) —
   goal-driven owns *why* and *how-far*; design-driven owns
@@ -384,7 +387,7 @@ Commit `goals/`, agent config updates, and any hook configs together.
 One commit, clear message:
 
 - First-run: `goal-driven: set GOAL.md and record scaffolding`
-- Update: `goal-driven: refresh CLAUDE.md block (siblings: <list>)`
+- Update: `goal-driven: refresh agent config blocks (siblings: <list>)`
 
 If update mode produced no actual changes (block already current,
 plumbing already in place), skip the commit — empty commits add noise.

--- a/skills/goal-driven/commands/set.md
+++ b/skills/goal-driven/commands/set.md
@@ -97,20 +97,61 @@ doesn't drop").
 
 Past 4 invariants, some are probably criteria or non-goals in disguise.
 
-### 2.4 Non-goals — what's tempting but isn't success
+### 2.4 Non-goals — the forbidden zones
 
-Extract the things the human will be tempted to call success later but
-explicitly aren't. Common patterns:
+Non-goals draw a perimeter: types of work that, even when tempting, this
+initiative will not pursue. They are **scope boundaries, not inverted
+goals.** The job of a non-goal is to pre-empt scope creep — when someone
+later argues "but it would be *great* if we also did X", the non-goal is
+the answer that has already been thought through.
 
-- Possible "phase 2" features — name as non-goals, not delayed goals
-- Adjacent improvements the team will be tempted to make along the way
-- Metrics that will rise as a side effect but aren't the point
+**The single most common failure: non-goals that are just goals
+restated in the negative.** "We want fast search → non-goal: slow
+search." That delimits nothing — nothing realistic was tempting in that
+direction. A real non-goal names *something an honest reviewer might
+lobby for* and then declines it, with a reason.
+
+Pressure-test each candidate with this question: *"If we did this,
+would we be doing the **wrong work**, or just **less of the right
+work**?"* Wrong-work items belong in non-goals. Less-of-the-right items
+belong in prioritization or as stretch notes — not in GOAL.md.
+
+Anti-pattern → fix:
+
+- "Don't ship a buggy product" — inverted goal; cut.
+- "Not for casual users" — too abstract. Turn it into a forbidden
+  scope: "No beginner onboarding flow this round; ships only for users
+  who already know the domain."
+- "Avoid scope creep" — meaningless. Name the specific creep: "No
+  generic policy platform across BUs — this initiative ships for one
+  BU's needs only."
+
+Common shapes that produce real non-goals:
+
+- **Adjacent platforms tempting to re-implement.** "We don't build our
+  own agent runtime — we integrate with existing frameworks." A
+  reviewer who thinks runtime ownership matters hits this line and
+  knows the trade-off was already weighed.
+- **Adjacent users we won't serve in this iteration.** "No multi-tenant
+  isolation; single-tenant only this round."
+- **Possible 'phase 2' features that will get lobbied for.** Name as
+  non-goals, not 'later goals'. 'Later' converges with 'now' under
+  pressure; 'forbidden, with a reason' doesn't.
+- **Metrics / outcomes that will rise as side effects.** Don't pretend
+  they're the goal: "Not optimizing for DAU — retention is the target;
+  DAU may move but isn't measured."
+- **Replacing systems we should integrate with.** "We don't rewrite
+  CRM/ticketing/IM — only integrate via tools."
 
 Most humans first say they don't have any non-goals. They do; they just
-haven't named them. Prompt with the patterns above until something
-lands.
+haven't named them. Prompt with: *"Is there work an outsider would
+suggest you should also do, that you've already decided against? Why?"*
+Then run candidates through the wrong-work / less-of-right test before
+accepting them.
 
-Echo each non-goal back; confirm.
+Echo each non-goal back **with the reason it's out of scope**, not just
+the name; confirm. A non-goal without a reason rots into a question mark
+the next time someone lobbies for it.
 
 ## Phase 3 — Draft
 
@@ -266,3 +307,8 @@ all 8 simultaneously, the goal is too compound — split or reframe.
 They do; they just haven't named them. Prompt with: "What did you almost
 include but decided to leave out? What would be a sign of scope creep
 later?"
+
+**Accepting inverted goals as non-goals.** "We want X → non-goal: not
+X" delimits nothing. If a non-goal candidate doesn't name a specific
+*tempting* path the initiative declines, it isn't doing the work of a
+non-goal. Push for a forbidden zone with a reason, or cut the line.

--- a/skills/goal-driven/references/example.md
+++ b/skills/goal-driven/references/example.md
@@ -60,19 +60,34 @@ existing keyword search API contract is unchanged*. OK?"
 
 **Human:** "Yes."
 
-**Agent:** "What's tempting to call success but isn't?"
+**Agent:** "What's tempting but explicitly out of scope — work an
+outside reviewer might lobby for that you've already decided against?"
 
 **Human:** "Cross-user search would be cool but is out. And multi-language
 — Chinese only for now, English nice-to-have but not blocking."
 
-**Agent:** "Non-goals: *cross-user search*; *multi-language beyond
-Chinese*. English support is desired but not required for success — should
-I write that as a non-goal too, or note it as a stretch?"
+**Agent:** "For each, the reason matters — it's what stops the line
+from rotting into a question mark next time someone lobbies. Why
+cross-user search out?"
+
+**Human:** "Privacy review would balloon scope; this is single-user
+search inside one's own history."
+
+**Agent:** "And multi-language beyond Chinese?"
+
+**Human:** "Embedding model trade-offs differ by language. Pinning to
+Chinese keeps the model choice simple."
+
+**Agent:** "Non-goals captured as: *cross-user search — privacy review
+would expand scope beyond a single user's own history*; *multi-language
+beyond Chinese — keeps embedding model choice simple, avoids
+per-language tuning*. English support is desired but not required —
+should I write that as a non-goal or note it as a stretch?"
 
 **Human:** "Note as stretch — don't make it a non-goal."
 
-**Agent:** "Got it. I'll add a note under Non-goals: 'English support is a
-stretch goal, not required for success'."
+**Agent:** "Got it. I'll add a note under Non-goals: 'English support
+is a stretch goal, not required for success'."
 
 (Agent writes `goals/GOAL.md`, shows it in chat, gets final OK, adds
 kickoff entry to `record-2026-04.md`.)

--- a/skills/goal-driven/references/templates.md
+++ b/skills/goal-driven/references/templates.md
@@ -37,10 +37,14 @@ signal even if criteria are on track.
 0–4 invariants is typical.
 
 ## Non-goals
-What's tempting to call success but isn't. The defense against scope creep.
+Forbidden zones — types of work that, even when tempting, this
+initiative declines. Each line names a specific *tempting* path and the
+reason it's out of scope. Not inverted goals ("don't ship slow
+search" delimits nothing). Test: would an honest reviewer ever lobby
+for this? If no, it's not a non-goal worth listing.
 
-- <non-goal 1>
-- <non-goal 2>
+- <forbidden zone 1> — <one-line reason>
+- <forbidden zone 2> — <one-line reason>
 
 ## Revisions
 Lightweight log of GOAL.md changes (git has the full diff; this is for


### PR DESCRIPTION
## Summary

Pilot for sibling-aware idempotent inits on **goal-driven**. After this lands and we like the shape, the same pattern rolls out to `design-driven init` and `evidence-driven init` in a follow-up PR.

The user pain: each skill's init currently writes an isolated CLAUDE.md snippet. When 2–3 sibling skills are installed, the resulting CLAUDE.md is fragmented and doesn't explain how they cooperate. Re-running an init was either undefined or "redo from scratch", so adding a sibling later required manual editing.

## Behavior change

- **`/goal-driven set` is now idempotent.** First run: unchanged (interview → write GOAL.md → scaffold). Re-run: **update mode** — skips the interview, refreshes plumbing and the CLAUDE.md block, never touches GOAL.md or records. For re-assessment use `/goal-driven review`, not `set`.
- **Sibling detection.** Phase 1.2 scans for `design/DESIGN.md` and for sibling marker blocks in CLAUDE.md.
- **Marker-block CLAUDE.md write.** The goal-driven snippet is wrapped in `<!-- skill:goal-driven --> ... <!-- /skill:goal-driven -->`. On re-run, the block is replaced between markers; first run appends. The block contains a conditional `### Interactions` subsection populated from detected siblings — describing how goal-driven divides labor with each.
- **Sibling refresh nudge.** After writing its own block, goal-driven prompts to re-run sibling inits so their blocks can pick up the reverse cross-references. Each skill still owns only its own marker block — no skill edits another's.
- **Empty-update commits skipped.** Re-runs that produced no diff don't create noise.

## Files

- `skills/goal-driven/commands/set.md` — Phase 1.1 mode dispatch, Phase 1.2 sibling detection, Phase 1.3 prior-context (incl. DESIGN.md if present), Phase 2 interview hooks for sibling context, Phase 4.2 marker block + Interactions, Phase 4.3 refresh nudge, Phase 4.4–4.7 renumbered with first-run-only / update-aware notes.
- `skills/goal-driven/SKILL.md` — command list and "which command when" updated to surface update-mode use case.

## Test plan

- [ ] Fresh project, run `/goal-driven set` → still interviews and writes GOAL.md as before. Verify CLAUDE.md block has markers and (no Interactions section, since no siblings).
- [ ] Same project, install design-driven and re-run `/goal-driven set` → no interview; goal-driven block replaced in place with an Interactions section mentioning design-driven; nudge to re-run `/design-driven init`.
- [ ] Run `/goal-driven set` twice in a row with no other changes → second run reports "Re-run produced no changes; setup is already current" and skips the commit.
- [ ] Re-do-from-scratch path (existing GOAL.md + explicit human request) still archives and starts over.

## Follow-ups

- Apply the same pattern to `/design-driven init` and `/evidence-driven init` (marker block, sibling detection, idempotent re-run, refresh nudge). Out of scope for this PR — wait for the goal-driven pilot to settle.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FmHKh6npPPenV8cY5YBxu)_