### PR TITLE
design-driven: blueprints become sibling-aware (Plan + Verify)

### DIFF
--- a/skills/design-driven/SKILL.md
+++ b/skills/design-driven/SKILL.md
@@ -222,6 +222,17 @@ DESIGN.md and the code. If those two disagree, that's drift; stop and
 run `/design-driven audit` rather than layer new work on a stale 
 skeleton.
 
+**If goal-driven is installed** (`goals/GOAL.md` exists), read it as 
+part of Plan and decide which success criteria this task moves 
+forward. Add a `**Serves:** C<n>, C<m>` line to the blueprint header 
+(or `**Serves:** none` for infra cleanup that doesn't directly serve 
+a criterion). This makes the blueprint → goal traceability visible 
+in two directions: a future reader sees why the task exists; the 
+goal-driven session-end record can cite the blueprint when checking 
+that criterion. If the task doesn't visibly serve any criterion and 
+isn't infra cleanup, that itself is a signal — pause and ask whether 
+this task belongs in this initiative.
+
 Then write `blueprints/<task-name>.md` with approach, scope, and 
 verification criteria upfront — how will you know this task is done? 
 The TODO and State sections are scaffolding: progress trackers, not 
@@ -260,6 +271,13 @@ quality, the evidence-driven skill is a sibling overlay that deepens
 this falsifiability rule (TDD cycle, anti-cargo-cult guards, evidence-
 trail State). Design-driven works alone without it; evidence-driven 
 adds rigor on top when the work calls for it.
+
+**If evidence-driven is installed** (its block is present in the 
+project's agent configs), each Verification check-off must cite a 
+falsifiable observation when ticked — `[x] tests pass — 14/14 in 
+store.test.ts`, not bare `[x]`. The evidence can sit inline next to 
+the check or be recorded in State and referenced by line. A 
+verification ticked without an observation is rejected on review.
 
 A failing test (or an observation during verify) that reveals something 
 DESIGN.md doesn't account for is a **signal about design silence**, not 

--- a/skills/design-driven/references/templates.md
+++ b/skills/design-driven/references/templates.md
@@ -11,10 +11,7 @@ Load this file when you need to create one of these artifacts.
 **Status:** in-progress | done
 **Date:** YYYY-MM-DD
 **Design context:** Which design/ sections this task relates to
-**Serves:** C2, C5  ← only if goal-driven is installed; list the GOAL
-                      criteria this task moves forward, or `none` if it
-                      doesn't serve any (e.g., infra cleanup). Omit the
-                      line entirely if goals/GOAL.md doesn't exist.
+**Serves:** C<n>, C<m> (or "none")
 
 ## Approach
 What this task builds and the approach chosen. More detailed than design/ 

--- a/skills/design-driven/references/templates.md
+++ b/skills/design-driven/references/templates.md
@@ -11,6 +11,10 @@ Load this file when you need to create one of these artifacts.
 **Status:** in-progress | done
 **Date:** YYYY-MM-DD
 **Design context:** Which design/ sections this task relates to
+**Serves:** C2, C5  ← only if goal-driven is installed; list the GOAL
+                      criteria this task moves forward, or `none` if it
+                      doesn't serve any (e.g., infra cleanup). Omit the
+                      line entirely if goals/GOAL.md doesn't exist.
 
 ## Approach
 What this task builds and the approach chosen. More detailed than design/ 
@@ -30,6 +34,11 @@ What's in / what's out for this task specifically.
 - [ ] Honors relevant Constraints and Non-goals
 - [ ] If shape changed: an adopted proposal exists in design/decisions/
 
+<!-- If evidence-driven is installed, each Verification check-off must
+     cite a falsifiable observation when ticked (e.g.,
+     "[x] tests pass — 14/14 in store.test.ts"). Bare `[x]` is rejected.
+     Record the evidence either inline next to the check or in State. -->
+
 ## TODO                          ← Scaffolding — removed at close out
 - [ ] Step 1 description
 - [ ] Step 2 description
@@ -45,6 +54,12 @@ Items that got scope-shaved but remain worth doing. Names and one-line
 intents, not full blueprints.
 - `<task-name>` — one-line intent
 ```
+
+The `Serves:` line and the evidence-discipline comment above are
+**conditional on sibling skills being installed**. If neither is
+present, the blueprint stays exactly as it was — these fields exist
+to make traceability visible when the surrounding methodology is
+already in play, not to add overhead when it isn't.
 
 ## Proposal format
 


### PR DESCRIPTION
## Summary

Make design-driven blueprints **sibling-aware** instead of making design-driven the orchestrator. The skill stays independently usable — when no siblings are installed, blueprints look exactly as before; when GOAL.md or evidence-driven exists, the blueprint surfaces the connection without forcing a workflow.

This is the *connective tissue* approach we discussed: design-driven is the most frequently touched of the three, and its blueprint is the only artifact that naturally references both GOAL criteria (*why this task*) and evidence-driven trails (*how it was verified*). Two small hooks let it carry that weight without becoming a control plane.

## Behavior change

- **Plan: which criterion does this task serve?** If `goals/GOAL.md` exists, reading it is part of Plan. The blueprint header gains a `**Serves:** C2, C5` line (or `**Serves:** none` for infra cleanup). Tasks that serve no criterion and aren't infra cleanup get flagged — that's a scope-creep canary.
- **Verify: cite evidence per check.** If evidence-driven's block is present in any agent config, each Verification check-off must cite a falsifiable observation when ticked. Bare `[x]` is rejected; the observation goes inline or in State.
- **No siblings → no change.** Both rules are conditional on filesystem detection. design-driven still works alone, and the example walkthrough is unchanged.

## Files

- `skills/design-driven/references/templates.md` — blueprint header gains conditional `Serves:` field with comment explaining when to omit it; Verification block gains a guidance comment about evidence citations.
- `skills/design-driven/SKILL.md` — Plan section explains when/how to read GOAL.md and emit `Serves:`; Verify section turns the existing evidence-driven mention into a concrete cite-rule.

## Test plan

- [ ] Run a design-driven Plan in a project with no `goals/` and no evidence-driven block → blueprint header is unchanged from before; Verification stays as it was.
- [ ] Same project with `goals/GOAL.md` present → blueprint includes `**Serves:**`. Confirm the agent flags tasks that serve no criterion.
- [ ] Project with evidence-driven block in CLAUDE.md → bare `[x]` Verification check-offs get rejected on review; reviewers see the evidence next to each check.

## Out of scope (follow-up)

- Apply the goal-driven init pattern (idempotent re-run, marker block, sibling-aware CLAUDE.md write) to `/design-driven init` and `/evidence-driven init`. Tracked separately; the blueprint awareness in this PR doesn't depend on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FmHKh6npPPenV8cY5YBxu)_