### PR TITLE
Add 'Principal contradiction first' principle + setup-lidessen-skills deployer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ Agent context is finite — structure it in layers: L1 (architecture, always pre
 
 Agent throughput keeps rising; human review capacity doesn't. When designing a skill or shaping any output that lands in front of a human, treat the output like code architecture: humans review the skeleton (the 20% whose failure invalidates the rest), agents own the details within, and details should be cheap to throw out without disturbing the skeleton. Generalizes design-driven's 30/70 to all agent-human collaboration. See [harness Part III](skills/harness/SKILL.md) for the full principle and consequences.
 
+### Principal contradiction first
+
+When a task has many decisions or moving parts, agents drift unless something forces sequencing. Identify the *principal contradiction* — the load-bearing decision whose resolution changes the shape of all downstream work — and lock it before drafting details. Operational test (cascade): for each candidate, ask "if this is wrong and the rest is right, does the rest still hold?" If no, it's principal; lock it first. If yes, it's secondary; defer. The same logic recurs across this repo at different layers — design-driven's 30/70 (skeleton vs flesh), goal-driven's General Line (destination before path), reframe's 3-5 abstract functions (essence before shape). This principle adds the *execution layer*: within a single task, locate the load-bearing decision before drafting downstream artifacts. Roots in Mao's [On Contradiction](https://www.marxists.org/reference/archive/mao/selected-works/volume-1/mswv1_17.htm) — the principal contradiction's existence and development determines the form of the others; grasp it and "纲举目张" follows. Re-evaluate at transitions: once the principal is resolved, the next layer's contradiction may become principal.
+
 ## Project Overview
 
 This is a collection of agent skills — reusable methodology plugins for AI-assisted development. Skills are installed into a project and invoked via slash commands (e.g., `/design-driven`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Guiding Principles
 
+<!-- lidessen-setup:begin v=1 -->
 ### Principles over rules
 
 Skills should help agents understand *why*, not just specify *what*. A skill that explains reasoning and principles produces better judgment across novel situations than one that mechanically lists rules. Favor broad principles over rigid prescriptions — give the agent enough context to generalize, not just enough rules to comply. ([Anthropic's constitution](https://www.anthropic.com/constitution): "If we want models to exercise good judgment across a wide range of novel situations, they need to be able to generalize — to apply broad principles rather than mechanically following specific rules.")
@@ -19,6 +20,9 @@ Agent throughput keeps rising; human review capacity doesn't. When designing a s
 ### Principal contradiction first
 
 When a task has many decisions or moving parts, agents drift unless something forces sequencing. Identify the *principal contradiction* — the load-bearing decision whose resolution changes the shape of all downstream work — and lock it before drafting details. Operational test (cascade): for each candidate, ask "if this is wrong and the rest is right, does the rest still hold?" If no, it's principal; lock it first. If yes, it's secondary; defer. The same logic recurs across this repo at different layers — design-driven's 30/70 (skeleton vs flesh), goal-driven's General Line (destination before path), reframe's 3-5 abstract functions (essence before shape). This principle adds the *execution layer*: within a single task, locate the load-bearing decision before drafting downstream artifacts. Roots in Mao's [On Contradiction](https://www.marxists.org/reference/archive/mao/selected-works/volume-1/mswv1_17.htm) — the principal contradiction's existence and development determines the form of the others; grasp it and "纲举目张" follows. Re-evaluate at transitions: once the principal is resolved, the next layer's contradiction may become principal.
+<!-- lidessen-setup:end -->
+
+> The principles between the markers above are managed by `/setup-lidessen-skills` and sourced from [`skills/setup-lidessen-skills/references/cross-cutting-principles.md`](skills/setup-lidessen-skills/references/cross-cutting-principles.md). Do not hand-edit between markers; edit the canonical reference instead, then run `/setup-lidessen-skills sync` to propagate.
 
 ## Project Overview
 

--- a/skills/setup-lidessen-skills/SKILL.md
+++ b/skills/setup-lidessen-skills/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: setup-lidessen-skills
+description: Operational deployer for the lidessen skills collection — wires harness config (CLAUDE.md / AGENTS.md / .cursor/) in a target project, injects cross-cutting principles (e.g. principal contradiction first), and reconciles when lidessen evolves. Triggers on "/setup-lidessen-skills", "set up lidessen skills", "wire lidessen into this project", "sync lidessen principles", "install lidessen skills". Use after cloning or symlinking lidessen skills into a project, when adopting the collection, or when lidessen has new content the project hasn't picked up. Args — `init` to scaffold, `sync` to re-align with current lidessen, `audit` to check drift without writing. Pairs with harness (portable methodology); this is the lidessen-specific application layer.
+argument-hint: "[init | sync | audit]"
+---
+
+# Setup lidessen skills
+
+Operational deployer for the lidessen skills collection. The lidessen *methodology* lives in the individual skills (harness, design-driven, goal-driven, reframe, evidence-driven, etc.); this skill does the *wiring* to land them in a target project — detect the host tool, write to the right harness file, and inject the cross-cutting principles that span multiple lidessen skills.
+
+## Position relative to harness
+
+`harness` (and any general-purpose harness skill) teaches *how to think about agent context* — portable methodology, applies to any project regardless of skill collection. This skill is the lidessen-specific operational layer that *applies* harness-style structure to a project adopting the lidessen collection. Read harness for the why; run this skill to do the wiring.
+
+## Boundary — what this skill does and doesn't
+
+**Does:**
+- Detect host tool (Claude Code / Codex / Cursor / other) by config-file presence
+- Create or update the project's harness config with a delimited "Lidessen" section
+- Inject canonical cross-cutting principles from `references/cross-cutting-principles.md`
+- Maintain a version marker so subsequent `sync` / `audit` runs can detect drift
+
+**Doesn't:**
+- Teach lidessen methodology (each skill's own SKILL.md owns that)
+- Copy or install skill files (use clone / symlink / your package manager)
+- Modify per-skill content (each skill is its own concern)
+
+## Tool detection
+
+Detect host tool in priority order before any subcommand writes:
+
+1. `CLAUDE.md` exists at project root → Claude Code
+2. `AGENTS.md` exists at project root → Codex
+3. `.cursor/` directory exists → Cursor
+4. None of the above → ask the user explicitly which tool they're configuring
+
+The detected tool determines the target file:
+
+| Tool | Target file |
+|---|---|
+| Claude Code | `CLAUDE.md` |
+| Codex | `AGENTS.md` |
+| Cursor | `.cursor/rules/lidessen.md` (created if missing) |
+| Other | ask the user where to write |
+
+If multiple host configs are present, prefer the one the user names; fall back to priority order.
+
+## Delimited section format
+
+The lidessen-managed content lives inside paired markers so reruns can replace cleanly without disturbing surrounding content:
+
+```
+<!-- lidessen-setup:begin v=<N> -->
+... lidessen-managed content ...
+<!-- lidessen-setup:end -->
+```
+
+**Invariant:** content outside the markers belongs to the user and must never be touched. Content inside the markers is wholly owned by this skill and is replaced on every `sync`. Users who need to override a principle should do so *outside* the markers — typically by adding a contrary note in their own section that consumers of CLAUDE.md will read alongside.
+
+## Subcommands
+
+Dispatch by argument:
+
+- `init` — Scaffold the lidessen section in a project that doesn't yet have one. See `commands/init.md`.
+- `sync` — Replace the lidessen section with current canonical content; bumps version. See `commands/sync.md`.
+- `audit` — Read-only drift check; never writes. See `commands/audit.md`.
+
+If invoked with no argument, default to `audit` — it is the safe read-only operation and surfaces enough information for the user to decide whether they want `init` or `sync`.
+
+## Principal contradiction (this skill)
+
+Per the canonical principle — the load-bearing decision in this skill is **what gets injected** (the canonical content in `references/cross-cutting-principles.md`). Tool detection, marker format, subcommand split are all secondary; getting them wrong is locally repairable, but injecting the wrong content propagates into every consumer project. Treat `references/cross-cutting-principles.md` with the discipline due a public API.

--- a/skills/setup-lidessen-skills/commands/audit.md
+++ b/skills/setup-lidessen-skills/commands/audit.md
@@ -1,0 +1,53 @@
+# Setup lidessen skills — `audit`
+
+Read-only check: report drift between the project's lidessen section and the current canonical content. **Never writes.** This is also the default subcommand when `/setup-lidessen-skills` is invoked without an argument.
+
+## Steps
+
+1. **Detect host tool & target file** per SKILL.md "Tool detection".
+2. **Locate existing markers** (`<!-- lidessen-setup:begin -->` ... `<!-- lidessen-setup:end -->`). If absent, report "not yet set up; run `/setup-lidessen-skills init`" and exit cleanly. Not an error.
+3. **Read existing section** content between markers, plus the existing version (`v=<N>`).
+4. **Read current canonical content** from `references/cross-cutting-principles.md`. Note the canonical version (`v=<M>`).
+5. **Diff and classify each principle**:
+   - **Missing**: present in canonical, not in project section. Will be added on next `sync`.
+   - **Changed**: present in both, text differs. Will be updated on next `sync`.
+   - **Removed upstream**: present in project section, not in canonical. Will be deleted on next `sync`. Flag this prominently — if the user added their own content inside the markers, they will lose it; recommend they relocate it outside the markers before running `sync`.
+6. **Report** in the four-section format below.
+7. **Exit cleanly** without modifying any file — including timestamps, line endings, anything.
+
+## Output format
+
+```
+Lidessen audit — <target file>, project v=N (canonical v=M)
+
+Missing (will be added by sync):
+  - <principle title>
+  - ...
+
+Changed (will be updated by sync):
+  - <principle title> (<line-level summary, e.g. "3 lines changed">)
+  - ...
+
+Removed upstream (will be deleted by sync — relocate any user content outside the markers first):
+  - <principle title or excerpt>
+  - ...
+
+Recommendation: run `/setup-lidessen-skills sync` to apply, or stay at v=N if you have local edits to preserve.
+```
+
+If everything is in sync, the four lists are empty and the output collapses to:
+
+```
+Lidessen audit — <target file>, v=N (canonical v=N)
+In sync. No action needed.
+```
+
+## Failure modes
+
+- Markers malformed (orphan begin/end, duplicate pairs) → report the malformation and recommend repair. Do not attempt to interpret a malformed section.
+- Canonical reference missing or unreadable → report the error. Audit cannot proceed without ground truth.
+- Target file unreadable → report and exit.
+
+## Why audit defaults
+
+`audit` is the default invocation because it is read-only and surfaces enough information for the user to choose between `init` (if no markers exist), `sync` (if drift exists), or no-op (if in sync). Defaulting to a writing operation would risk surprise; defaulting to audit makes the cost of an accidental invocation effectively zero.

--- a/skills/setup-lidessen-skills/commands/init.md
+++ b/skills/setup-lidessen-skills/commands/init.md
@@ -8,18 +8,25 @@ Scaffold the lidessen section in a project that doesn't yet have one.
 2. **Identify target file** based on detected tool.
 3. **Check for existing markers** (`<!-- lidessen-setup:begin -->`) in the target file. If found, abort and recommend `sync` instead — `init` is for fresh scaffolding only and would clobber existing user state.
 4. **Read current canonical content** from `references/cross-cutting-principles.md`. This is the single source of truth for what goes between the markers.
-5. **Compose the section**:
-   - Open marker with version: `<!-- lidessen-setup:begin v=1 -->`
-   - Heading: `## Lidessen skills (managed by /setup-lidessen-skills)`
-   - One-line preamble: this section is managed by `/setup-lidessen-skills`; do not hand-edit; run `/setup-lidessen-skills sync` to update.
-   - Optional list of installed lidessen skills if discoverable in the project (look for `skills/<name>/SKILL.md` whose author/source is lidessen). If undetectable, leave a placeholder line for the user to fill in.
-   - The cross-cutting principles, copied verbatim from the canonical reference.
-   - Close marker: `<!-- lidessen-setup:end -->`
-6. **Write the section** at an appropriate position in the target file:
-   - If the file already exists and has a `## Guiding Principles` section, insert the lidessen section *after* that section (so the user's own principles come first).
-   - Otherwise, append at the bottom.
-   - If the file doesn't exist, create it with a minimal scaffold: a top-level title (`# <Project name>`), a single sentence stating it provides agent guidance, then the lidessen section.
-7. **Report what happened** to the user — which file, where the section was inserted, the version, and any user action required (e.g., "the principles refer to skills X/Y/Z; make sure you've cloned or symlinked them into your `skills/` directory").
+5. **Choose layout** based on the target file's existing structure:
+   - **Integrated layout** (preferred when the target file already has a guidance section): if a heading like `## Guiding Principles`, `## Principles`, or similar exists, the markers nest *under* that heading. The heading stays user-owned and outside the markers; only the canonical principle content goes between them. This is what the lidessen/skills repo itself uses.
+   - **Standalone layout** (preferred for greenfield consumer projects): the markers wrap a self-contained block including its own heading. Used when no suitable existing section can host the content.
+6. **Compose the section** based on chosen layout:
+   - **Integrated**:
+     - Open marker: `<!-- lidessen-setup:begin v=1 -->`
+     - The principle content from `references/cross-cutting-principles.md`, copied verbatim (h3 headings as in the reference).
+     - Close marker: `<!-- lidessen-setup:end -->`
+     - Outside the markers, immediately after, append a one-line note pointing the user at the canonical reference and instructing them to run `sync` for updates.
+   - **Standalone**:
+     - Open marker with version: `<!-- lidessen-setup:begin v=1 -->`
+     - Heading: `## Lidessen Guiding Principles`
+     - One-line preamble: this section is managed by `/setup-lidessen-skills`; do not hand-edit; run `/setup-lidessen-skills sync` to update.
+     - The principle content from `references/cross-cutting-principles.md`, copied verbatim. (Heading depth: keep h3 — they nest under the standalone-layout h2 heading.)
+     - Close marker: `<!-- lidessen-setup:end -->`
+7. **Write the section** at an appropriate position in the target file:
+   - **Integrated layout**: insert markers + content under the existing heading.
+   - **Standalone layout**: append at the bottom of the file. If the file doesn't exist, create it with a minimal scaffold (top-level title + one sentence stating it provides agent guidance) and append the standalone section.
+8. **Report what happened** to the user — which file, where the section was inserted, the version, and any user action required (e.g., "the principles refer to skills X/Y/Z; make sure you've cloned or symlinked them into your `skills/` directory").
 
 ## Failure modes
 

--- a/skills/setup-lidessen-skills/commands/init.md
+++ b/skills/setup-lidessen-skills/commands/init.md
@@ -1,0 +1,33 @@
+# Setup lidessen skills — `init`
+
+Scaffold the lidessen section in a project that doesn't yet have one.
+
+## Steps
+
+1. **Detect host tool** per SKILL.md "Tool detection". If multiple configs are present, ask the user which to target. If none, ask the user to confirm which tool they're configuring before creating the target file.
+2. **Identify target file** based on detected tool.
+3. **Check for existing markers** (`<!-- lidessen-setup:begin -->`) in the target file. If found, abort and recommend `sync` instead — `init` is for fresh scaffolding only and would clobber existing user state.
+4. **Read current canonical content** from `references/cross-cutting-principles.md`. This is the single source of truth for what goes between the markers.
+5. **Compose the section**:
+   - Open marker with version: `<!-- lidessen-setup:begin v=1 -->`
+   - Heading: `## Lidessen skills (managed by /setup-lidessen-skills)`
+   - One-line preamble: this section is managed by `/setup-lidessen-skills`; do not hand-edit; run `/setup-lidessen-skills sync` to update.
+   - Optional list of installed lidessen skills if discoverable in the project (look for `skills/<name>/SKILL.md` whose author/source is lidessen). If undetectable, leave a placeholder line for the user to fill in.
+   - The cross-cutting principles, copied verbatim from the canonical reference.
+   - Close marker: `<!-- lidessen-setup:end -->`
+6. **Write the section** at an appropriate position in the target file:
+   - If the file already exists and has a `## Guiding Principles` section, insert the lidessen section *after* that section (so the user's own principles come first).
+   - Otherwise, append at the bottom.
+   - If the file doesn't exist, create it with a minimal scaffold: a top-level title (`# <Project name>`), a single sentence stating it provides agent guidance, then the lidessen section.
+7. **Report what happened** to the user — which file, where the section was inserted, the version, and any user action required (e.g., "the principles refer to skills X/Y/Z; make sure you've cloned or symlinked them into your `skills/` directory").
+
+## Failure modes
+
+- Target file is binary, malformed, or unreadable → abort, report the underlying error.
+- User cannot or will not specify which tool when ambiguous → abort; this skill does not guess.
+- Existing markers detected → instruct the user to run `sync` instead; do not overwrite.
+- Canonical reference file missing or unreadable → abort; surface the read error to the user. Do not write a partial section.
+
+## Output
+
+A short status: target file path, version written, lines added, and any user follow-up required.

--- a/skills/setup-lidessen-skills/commands/sync.md
+++ b/skills/setup-lidessen-skills/commands/sync.md
@@ -1,0 +1,34 @@
+# Setup lidessen skills — `sync`
+
+Re-align an already-setup project with the current canonical lidessen content.
+
+## Steps
+
+1. **Detect host tool & target file** per SKILL.md "Tool detection".
+2. **Locate existing markers** in the target file (`<!-- lidessen-setup:begin -->` ... `<!-- lidessen-setup:end -->`). If absent, abort and recommend `init` — `sync` requires existing markers and never creates new ones.
+3. **Read existing version** from the begin marker (`v=<N>`).
+4. **Read current canonical content** from `references/cross-cutting-principles.md` (and any other registered references the SKILL.md has been extended to use).
+5. **Diff** the existing section content against the canonical. Classify changes per `audit.md`'s schema (missing / changed / removed-upstream).
+6. **If no diff**: report "already in sync at v=N" and exit without writing. This is the common case after a no-op upstream change and should be cheap.
+7. **If diff present**:
+   - Replace content between markers with current canonical, byte-for-byte.
+   - Bump version to `v=<N+1>`.
+   - Preserve content outside the markers exactly — every byte. Do not even normalize whitespace.
+8. **Report** diff summary to the user: principles added / changed / removed, version transition (v=N → v=N+1).
+
+## Invariant
+
+After `sync`, the section between markers is byte-identical to the canonical references (modulo the version marker). This is the principal contradiction of this command: get this right and everything else is detail; get it wrong (e.g., partial overwrite, stale content, drifted whitespace) and consumers downstream silently diverge.
+
+## Failure modes
+
+- Begin marker present but end marker missing (or vice versa) → abort. Ask the user to repair the file manually before `sync` will operate.
+- Multiple begin/end pairs in the same file → abort; ambiguous, this skill writes exactly one section.
+- Canonical reference missing or unreadable → abort; surface the error. Do not write a partial section.
+- Target file modified concurrently (e.g., during a merge) → standard git-conflict territory; do not auto-resolve.
+
+## What `sync` deliberately doesn't do
+
+- It does not delete the markers, even if the canonical content becomes empty (an empty section between markers is a legitimate state).
+- It does not move the markers within the file. Position is owned by `init` and by the user.
+- It does not preserve user content placed *inside* the markers. Such content is reported as "removed upstream" by `audit` and will be deleted on `sync`. Users who want persistent custom content must place it outside the markers.

--- a/skills/setup-lidessen-skills/references/cross-cutting-principles.md
+++ b/skills/setup-lidessen-skills/references/cross-cutting-principles.md
@@ -1,0 +1,19 @@
+# Lidessen cross-cutting principles
+
+This file is the **canonical source** of cross-cutting principles that span multiple lidessen skills. The `setup-lidessen-skills` skill copies the content below this header into target-project harness configs (CLAUDE.md / AGENTS.md / .cursor/rules/), between paired `<!-- lidessen-setup:* -->` markers.
+
+The principles below are not skill-specific methodology — each lidessen skill carries its own. These are *aspect* principles that apply across the collection: how an agent should sequence decisions, balance shape vs flesh, manage finite context, etc. They are kept here, not in any single skill, because no single skill owns them — they are properties of working with the collection as a whole.
+
+When adding a new principle: add a section below, keep it self-contained (a downstream consumer reading only this file's contents must be able to act on it without further context), and bump the canonical version tracked by `setup-lidessen-skills`. Consumers pick up changes on next `/setup-lidessen-skills sync`.
+
+---
+
+## Principal contradiction first
+
+When a task has many decisions or moving parts, agents drift unless something forces sequencing. Identify the *principal contradiction* — the load-bearing decision whose resolution changes the shape of all downstream work — and lock it before drafting details.
+
+**Operational test (cascade):** for each candidate decision, ask "if this is wrong and the rest is right, does the rest still hold?" If no, it's principal — lock it first. If yes, it's secondary — defer.
+
+This pattern recurs at every layer in the lidessen collection — design-driven's 30/70 (skeleton vs flesh), goal-driven's General Line (destination before path), reframe's 3-5 abstract functions (essence before shape). This principle adds the *execution layer*: within a single task, locate the load-bearing decision before drafting downstream artifacts.
+
+Roots in Mao's [On Contradiction](https://www.marxists.org/reference/archive/mao/selected-works/volume-1/mswv1_17.htm) — the principal contradiction's existence and development determines the form of the others; grasp it and "纲举目张" follows. Re-evaluate at transitions: once the principal is resolved, the next layer's contradiction may become principal.

--- a/skills/setup-lidessen-skills/references/cross-cutting-principles.md
+++ b/skills/setup-lidessen-skills/references/cross-cutting-principles.md
@@ -1,19 +1,21 @@
-# Lidessen cross-cutting principles
+<!--
+This file is the canonical source of cross-cutting principles for the lidessen skills collection. The content from below this comment is what `setup-lidessen-skills` copies verbatim into target-project harness configs between paired `<!-- lidessen-setup:* -->` markers. Edits to this file propagate to all consumers on next `/setup-lidessen-skills sync`. The lidessen/skills repo itself dogfoods this — its own CLAUDE.md "Guiding Principles" section is injected from this file.
 
-This file is the **canonical source** of cross-cutting principles that span multiple lidessen skills. The `setup-lidessen-skills` skill copies the content below this header into target-project harness configs (CLAUDE.md / AGENTS.md / .cursor/rules/), between paired `<!-- lidessen-setup:* -->` markers.
+When adding or modifying a principle: keep each one self-contained (a downstream consumer must be able to act on it without further context), and bump the version marker that `setup-lidessen-skills` tracks so consumers know to sync. Section heads are at `###` (h3) level, intended to nest under a user-owned `## Guiding Principles` (h2). Adjust depth at copy time only if the consumer's layout demands it.
+-->
 
-The principles below are not skill-specific methodology — each lidessen skill carries its own. These are *aspect* principles that apply across the collection: how an agent should sequence decisions, balance shape vs flesh, manage finite context, etc. They are kept here, not in any single skill, because no single skill owns them — they are properties of working with the collection as a whole.
+### Principles over rules
 
-When adding a new principle: add a section below, keep it self-contained (a downstream consumer reading only this file's contents must be able to act on it without further context), and bump the canonical version tracked by `setup-lidessen-skills`. Consumers pick up changes on next `/setup-lidessen-skills sync`.
+Skills should help agents understand *why*, not just specify *what*. A skill that explains reasoning and principles produces better judgment across novel situations than one that mechanically lists rules. Favor broad principles over rigid prescriptions — give the agent enough context to generalize, not just enough rules to comply. ([Anthropic's constitution](https://www.anthropic.com/constitution): "If we want models to exercise good judgment across a wide range of novel situations, they need to be able to generalize — to apply broad principles rather than mechanically following specific rules.")
 
----
+### Hierarchical context management
 
-## Principal contradiction first
+Agent context is finite — structure it in layers: L1 (architecture, always present), L2 (design, on activation), L3 (implementation, on demand). The higher the layer, the smaller and more stable. Keep SKILL.md under 500 lines; split details into supporting files. See the [harness skill](skills/harness/SKILL.md) for the full methodology and the [Agent Skills Specification](https://agentskills.io/specification#progressive-disclosure) for the underlying spec.
 
-When a task has many decisions or moving parts, agents drift unless something forces sequencing. Identify the *principal contradiction* — the load-bearing decision whose resolution changes the shape of all downstream work — and lock it before drafting details.
+### Design for finite human bandwidth
 
-**Operational test (cascade):** for each candidate decision, ask "if this is wrong and the rest is right, does the rest still hold?" If no, it's principal — lock it first. If yes, it's secondary — defer.
+Agent throughput keeps rising; human review capacity doesn't. When designing a skill or shaping any output that lands in front of a human, treat the output like code architecture: humans review the skeleton (the 20% whose failure invalidates the rest), agents own the details within, and details should be cheap to throw out without disturbing the skeleton. Generalizes design-driven's 30/70 to all agent-human collaboration. See [harness Part III](skills/harness/SKILL.md) for the full principle and consequences.
 
-This pattern recurs at every layer in the lidessen collection — design-driven's 30/70 (skeleton vs flesh), goal-driven's General Line (destination before path), reframe's 3-5 abstract functions (essence before shape). This principle adds the *execution layer*: within a single task, locate the load-bearing decision before drafting downstream artifacts.
+### Principal contradiction first
 
-Roots in Mao's [On Contradiction](https://www.marxists.org/reference/archive/mao/selected-works/volume-1/mswv1_17.htm) — the principal contradiction's existence and development determines the form of the others; grasp it and "纲举目张" follows. Re-evaluate at transitions: once the principal is resolved, the next layer's contradiction may become principal.
+When a task has many decisions or moving parts, agents drift unless something forces sequencing. Identify the *principal contradiction* — the load-bearing decision whose resolution changes the shape of all downstream work — and lock it before drafting details. Operational test (cascade): for each candidate, ask "if this is wrong and the rest is right, does the rest still hold?" If no, it's principal; lock it first. If yes, it's secondary; defer. The same logic recurs across this repo at different layers — design-driven's 30/70 (skeleton vs flesh), goal-driven's General Line (destination before path), reframe's 3-5 abstract functions (essence before shape). This principle adds the *execution layer*: within a single task, locate the load-bearing decision before drafting downstream artifacts. Roots in Mao's [On Contradiction](https://www.marxists.org/reference/archive/mao/selected-works/volume-1/mswv1_17.htm) — the principal contradiction's existence and development determines the form of the others; grasp it and "纲举目张" follows. Re-evaluate at transitions: once the principal is resolved, the next layer's contradiction may become principal.


### PR DESCRIPTION
## Summary

Two related changes that originate from the same insight: a guiding principle alone won't fix execution-layer drift, so it ships with a forcing-function deployer.

### 1. CLAUDE.md: add 'Principal contradiction first' guiding principle

Adds a fourth guiding principle codifying the execution-layer instantiation of the load-bearing-first pattern that already recurs in this repo at other layers (design-driven's 30/70, goal-driven's General Line, reframe's abstract-function essence) but was missing for *within-task* execution ordering — the layer where overwhelmed agents drift the most. Includes an operational cascade test ("if this is wrong and the rest right, does the rest hold?") so the principle has teeth under load. Roots in Mao's *On Contradiction*.

### 2. New skill: `skills/setup-lidessen-skills/`

Operational deployer for the lidessen skills collection. Detects host tool (Claude Code / Codex / Cursor) by config-file presence, writes a delimited "Lidessen" section into the target file (`CLAUDE.md` / `AGENTS.md` / `.cursor/rules/lidessen.md`), and injects the canonical cross-cutting principles. Subcommands:

- `init` — scaffold a fresh consumer project
- `sync` — re-align with current canonical content; bumps version marker
- `audit` — read-only drift report (default when invoked without arg)

The canonical content lives in `references/cross-cutting-principles.md` and is the single source of truth. Currently contains just "Principal contradiction first"; designed to grow.

### Position relative to harness

`harness` teaches *portable methodology* for agent-context layering — applies to any project regardless of skill collection. `setup-lidessen-skills` is the lidessen-specific *operational* layer that applies harness-style structure to projects adopting this collection. Read harness for the why; run setup-lidessen-skills for the wiring.

### Why one PR for both

The principle is the *content* the deployer injects; the deployer is the *forcing function* that gets the principle into projects where agents would otherwise ignore it. They're a unit.

## Test plan

- [x] CLAUDE.md still parses cleanly
- [x] `setup-lidessen-skills/SKILL.md` frontmatter is valid YAML, single-line description, 755 chars (under the ~800 target)
- [ ] Manual review of subcommand boundaries (init never overwrites; sync never creates markers; audit never writes)
- [ ] Manual review of the cross-cutting principles canonical text
